### PR TITLE
CT-46 Add missing license and copyright header

### DIFF
--- a/src/main/java/com/scalyr/integrations/kafka/mapping/CustomAppEventMapping.java
+++ b/src/main/java/com/scalyr/integrations/kafka/mapping/CustomAppEventMapping.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Scalyr Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.scalyr.integrations.kafka.mapping;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/com/scalyr/integrations/kafka/mapping/CustomAppMessageMapper.java
+++ b/src/main/java/com/scalyr/integrations/kafka/mapping/CustomAppMessageMapper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Scalyr Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.scalyr.integrations.kafka.mapping;
 
 import org.apache.kafka.connect.sink.SinkRecord;

--- a/src/test/java/com/scalyr/integrations/kafka/mapping/CustomAppMessageMapperTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/mapping/CustomAppMessageMapperTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Scalyr Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.scalyr.integrations.kafka.mapping;
 
 import com.scalyr.integrations.kafka.TestUtils;


### PR DESCRIPTION
Add missing license and copyright header in new files.  Should be a quick review.  Thanks!