### PR TITLE
CT-73 Filebeat `source` shows up as `Kafka-<topic>` when running in container

### DIFF
--- a/src/main/java/com/scalyr/integrations/kafka/mapping/FilebeatMessageMapper.java
+++ b/src/main/java/com/scalyr/integrations/kafka/mapping/FilebeatMessageMapper.java
@@ -49,7 +49,7 @@ import java.util.List;
 public class FilebeatMessageMapper implements MessageMapper {
   private static final List<String> MESSAGE_FIELDS = ImmutableList.of("message");
   private static final List<String> LOGFILE_FIELDS = ImmutableList.of("log", "file", "path");
-  private static final List<String> SERVERHOST_FIELDS = ImmutableList.of("host", "hostname");
+  private static final List<String> SERVERHOST_FIELDS = ImmutableList.of("host", "name");
   private static final List<String> PARSER_FIELDS = ImmutableList.of("fields", "parser");
   private static final List<String> SOURCE_TYPE_FIELDS = ImmutableList.of("agent", "type");
   private static final String FILEBEAT = "filebeat";

--- a/src/test/java/com/scalyr/integrations/kafka/mapping/FilebeatMessageMapperTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/mapping/FilebeatMessageMapperTest.java
@@ -105,7 +105,7 @@ public class FilebeatMessageMapperTest {
       value.put("message", TestValues.MESSAGE_VALUE);
 
       // {host: {hostname: myhost}}
-      value.put("host", TestUtils.makeMap("hostname", TestValues.SERVER_VALUE + random.nextInt(numServers)));
+      value.put("host", TestUtils.makeMap("name", TestValues.SERVER_VALUE + random.nextInt(numServers)));
 
       // {log: {file: {path: /var/log/syslog}}};
       final Map<String, Object> file_path = new HashMap<>();
@@ -130,7 +130,7 @@ public class FilebeatMessageMapperTest {
       assertTrue(numParsers <= numLogFiles);
 
       final Schema hostSchema = SchemaBuilder.struct().name("host")
-        .field("hostname", Schema.STRING_SCHEMA).build();
+        .field("name", Schema.STRING_SCHEMA).build();
 
       final Schema fileSchema = SchemaBuilder.struct().name("file")
         .field("path", Schema.STRING_SCHEMA);
@@ -155,7 +155,7 @@ public class FilebeatMessageMapperTest {
 
       Struct value = new Struct(filebeatsSchema);
       value.put("message", TestValues.MESSAGE_VALUE);
-      value.put("host", new Struct(hostSchema).put("hostname", TestValues.SERVER_VALUE + random.nextInt(numServers)));
+      value.put("host", new Struct(hostSchema).put("name", TestValues.SERVER_VALUE + random.nextInt(numServers)));
 
       final int logFileNum = random.nextInt(numLogFiles);
       value.put("log", new Struct(logSchema).put("file", new Struct(fileSchema).put("path", TestValues.LOGFILE_VALUE + logFileNum)));


### PR DESCRIPTION
Filebeat `source` shows up as `Kafka-<topic>`, which is the default when the `source` `serverHost` is `null`. The reason for this is that when running in containers, the hostname field is in `host.name` instead of `host.hostname`.  When running in non-container, the hostname is in both `host.name` and `host.hostname`.

Fix: change the Filebeat mapping to use `host.name` instead of `host.hostname`.