### PR TITLE
Fix SonarCloud issue with indexOf check

### DIFF
--- a/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkConnectorConfig.java
+++ b/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkConnectorConfig.java
@@ -114,7 +114,7 @@ public class ScalyrSinkConnectorConfig extends AbstractConfig {
         throw new ConfigException("Enrichment value must be key=value");
       }
 
-      if (keyValue.indexOf(' ') > 0) {
+      if (keyValue.indexOf(' ') >= 0) {
         throw new ConfigException("Enrichment value cannot have spaces");
       }
     }


### PR DESCRIPTION
Fix "indexOf" checks should not be for positive numbers: 
Most checks against an indexOf value compare it with -1 because 0 is a valid index. Any checks which look for values >0 ignore the first element, which is likely a bug. If the intent is merely to check inclusion of a value in a String or a List, consider using the contains method instead.

This rule raises an issue when an indexOf value retrieved either from a String or a List is tested against >0.

