### PR TITLE
Fix system test events have same time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
 
   flog:
     image: mingrammer/flog
-    command: /bin/flog --loop --format apache_combined --delay 0.02
+    command: /bin/flog --loop --format apache_combined --delay 0.02 --sleep 1
     depends_on:
       - filebeat
 
@@ -110,7 +110,7 @@ services:
 
   flog-fluentd:
     image: mingrammer/flog
-    command: /bin/flog --loop --format apache_combined --delay 0.02
+    command: /bin/flog --loop --format apache_combined --delay 0.02 --sleep 1
     depends_on:
       - fluentd
     logging:

--- a/src/test/SystemTest/docker/fluentd/fluent.conf
+++ b/src/test/SystemTest/docker/fluentd/fluent.conf
@@ -27,7 +27,6 @@
 
   # list of seed brokers
   brokers kafka:29092
-  use_event_time true
 
   # buffer settings
   <buffer topic>


### PR DESCRIPTION

**flog**
flog is generating logs with the same timestamp.  Without the `--sleep 1`, flog uses the the same time for the log messages.
Ref: https://github.com/mingrammer/flog

**fluentd**
Setting `use_event_time:true` resulted in all the Fluentd Kafka events having the same timestamp.  Remove `use_event_time`, which will default it to false. This means use current time.
Ref: https://docs.fluentd.org/output/kafka#use_event_time