### PR TITLE
CT-90 Large message sizes causes add events 6 MB max batch size to be exceeded

### DIFF
--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -17,6 +17,7 @@
 package com.scalyr.integrations.kafka;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.scalyr.api.internal.ScalyrUtil;
 import com.scalyr.integrations.kafka.AddEventsClient.AddEventsRequest;
 import com.scalyr.integrations.kafka.AddEventsClient.AddEventsResponse;
@@ -66,7 +67,7 @@ public class AddEventsClientTest {
   private static final String SEQUENCE_ID = "si";
   private static final String SEQUENCE_NUM = "sn";
   private static final String ATTRS = "attrs";
-  private static final String EVENTS = "events";
+  @VisibleForTesting static final String EVENTS = "events";
   private static final String LOG_ID = "log";
   private static final String LOGS = "logs";
   private static final String ID = "id";


### PR DESCRIPTION
Previously, `batch_send_size_bytes` was checked after adding all the `SinkRecords` in a `put` call.  This may cause the batch size to exceed the add events max 6 MB limit if the `put` batch contains a large number of records or the message size in the records is large.

Change the batching logic to check `batch_send_size_bytes` after adding each record instead of the entire `put` batch.  `addEvents` is called once `batch_send_size_bytes` is met. 