### PR TITLE
Fix custom app sample config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Kafka Connect Scalyr Sink Plugin
 
 [![CircleCI](https://circleci.com/gh/scalyr/kafka-connect-scalyr.svg?style=svg)](https://circleci.com/gh/scalyr/kafka-connect-scalyr)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=scalyr_kafka-connect-scalyr&metric=alert_status)](https://sonarcloud.io/dashboard?id=scalyr_kafka-connect-scalyr)
 
 This repository holds the source code for the Kafka Connect Scalyr Sink,
 which is a Kafka Connect Sink Connector that allows streaming log messages from a Kafka topic to Scalyr.

--- a/config/connect-scalyr-sink-custom-app.json
+++ b/config/connect-scalyr-sink-custom-app.json
@@ -8,6 +8,6 @@
     "topics": "logs",
     "api_key": "<log write api key from https://app.scalyr.com/keys>",
     "event_enrichment": "key1=value1,key2=value2",
-    "custom_app_event_mapping":"[{\"matcher\": {\"attribute\": \"app.name\", \"value\": \"myapp\"}, \"eventMapping\": {\"message\": \"message\", \"logfile\": \"log.path\", \"source\": \"host.hostname\", \"parser\": \"fields.parser\", \"version\": \"app.version\", \"appField1\":\"appField1\", \"appField2\":\"nested.appField2\"}}]"
+    "custom_app_event_mapping":"[{\"matcher\": {\"attribute\": \"app.name\", \"value\": \"myapp\"}, \"eventMapping\": {\"message\": \"message\", \"logfile\": \"log.path\", \"serverHost\": \"host.hostname\", \"parser\": \"fields.parser\", \"version\": \"app.version\", \"appField1\":\"appField1\", \"appField2\":\"nested.appField2\"}}]"
   }
 }

--- a/config/connect-scalyr-sink.properties
+++ b/config/connect-scalyr-sink.properties
@@ -17,7 +17,7 @@ api_key=<log write api key from https://app.scalyr.com/keys>
 #event_enrichment=key1=value1,key2=value2
 
 # Custom application event mapping - only needed for custom applications
-#custom_app_event_mapping=[{"matcher": {"attribute": "app.name", "value": "myapp"}, "eventMapping": {"message": "message", "logfile": "log.path", "source": "host.hostname", "parser": "fields.parser", "version": "app.version", "appField1", "appField1", "appField2", "nested.appField2"}}]
+#custom_app_event_mapping=[{"matcher": {"attribute": "app.name", "value": "myapp"}, "eventMapping": {"message": "message", "logfile": "log.path", "serverHost": "host.hostname", "parser": "fields.parser", "version": "app.version", "appField1", "appField1", "appField2", "nested.appField2"}}]
 
 # Advanced configuration options - these should not be modified in most cases
 # Compression type to use for sending log events.  Valid values are: `deflate`, `none`.


### PR DESCRIPTION
Made the following changes:
1. Sample custom app config incorrectly had `source` as the attribute name.  Changed `source` to `serverHost`.
2. Also removed Sonar Cloud badge because Sonar Cloud is now private.