### PR TITLE
CT-90 Improve per event size estimate

### DIFF
--- a/src/main/java/com/scalyr/integrations/kafka/Event.java
+++ b/src/main/java/com/scalyr/integrations/kafka/Event.java
@@ -46,6 +46,9 @@ public class Event {
   private String message;
   private Map<String, Object> additionalAttrs;
 
+  // Estimated per event serialization overhead: 16 bytes add events JSON format, 16 bytes timestamp, 16 bytes Kafka offset
+  private static final int EVENT_SERIALIZATION_OVERHEAD_BYTES = 48;
+
   // Setters
   public Event setTopic(String topic) {
     this.topic = topic;
@@ -159,6 +162,8 @@ public class Event {
    */
   public int estimatedSerializedBytes() {
     int size = getMessage() == null ? 0 : getMessage().length();
+    size += getTopic().length();
+    size += EVENT_SERIALIZATION_OVERHEAD_BYTES;
 
     if (getAdditionalAttrs() != null) {
       size += getAdditionalAttrs().entrySet().stream()


### PR DESCRIPTION
`org.apache.kafka.connect.errors.ConnectException: {"status":"error/client/badParam", "message":"input too long (maximum 6000000 characters)"}` occurs with small message sizes like 64 bytes even when the send events batch size is set to 4 MB.

The reason for this is the event size estimate did not include add events JSON overhead, timestamp, topic, and offset. Although these fields are ~84 bytes, this is a considerable overhead for small message sizes like 64 bytes.

Fix is to include topic and a fixed estimated overhead of 84 bytes per message.