### PR TITLE
Skip Add Events Requests > 6 MB

### DIFF
--- a/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
+++ b/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.RateLimiter;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.scalyr.api.internal.ScalyrUtil;
 import org.apache.http.HttpStatus;
@@ -91,6 +92,20 @@ public class AddEventsClient implements AutoCloseable {
    * Default Timeout Add Events Response
    */
   private static final AddEventsResponse TIMEOUT_ADD_EVENTS_RESPONSE = new AddEventsResponse().setStatus("Timeout").setMessage("Timeout");
+
+  /** Add events API has max payload size of 6 MB */
+  private static final int MAX_ADD_EVENTS_PAYLOAD_BYTES = 6000000;
+
+  /**
+   * Response when an add events request exceeds MAX_ADD_EVENTS_PAYLOAD_BYTES.  We skip add event requests > 6 MB
+   * since it will be rejected by the server.  Success is returned to the caller so it won't be retried.
+   */
+  private static final AddEventsResponse PAYLOAD_TOO_LARGE = new AddEventsResponse().setStatus(AddEventsResponse.SUCCESS).setMessage("Skipped due to payload too large");
+
+  /**
+   * Limit number of add events payloads that are logged when MAX_ADD_EVENTS_PAYLOAD_BYTES is exceeded
+   */
+  private static final RateLimiter payloadTooLargeLogRateLimiter = RateLimiter.create(1.0/900);  // 1 permit every 15 minutes
 
   /**
    * AddEventsClient which allows a mockable sleep for testing.
@@ -170,6 +185,16 @@ public class AddEventsClient implements AutoCloseable {
    */
   private AddEventsResponse addEventsWithRetry(byte[] addEventsPayload, long startTimeMs) {
     log.debug("addEvents payload size {} bytes", addEventsPayload.length);
+
+    // 6 MB add events payload exceeded.  Log the issue and skip this message.
+    if (addEventsPayload.length > MAX_ADD_EVENTS_PAYLOAD_BYTES) {
+      log.error("Add events payload size {} exceeds maximum size.  Skipping this add events request.  Log data will be lost", addEventsPayload.length);
+      if (payloadTooLargeLogRateLimiter.tryAcquire()) {
+        log.error("Add events too large payload: {}", new String(addEventsPayload));
+      }
+      return PAYLOAD_TOO_LARGE;
+    }
+
     AddEventsResponse addEventsResponse = TIMEOUT_ADD_EVENTS_RESPONSE;
     long delayTimeMs = initialBackoffDelayMs;
     httpPost.setEntity(new ByteArrayEntity(addEventsPayload));

--- a/src/main/java/com/scalyr/integrations/kafka/Event.java
+++ b/src/main/java/com/scalyr/integrations/kafka/Event.java
@@ -16,9 +16,12 @@
 
 package com.scalyr.integrations.kafka;
 
+import com.google.common.base.Suppliers;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 /**
  * Abstraction for a Scalyr Event.
@@ -158,9 +161,18 @@ public class Event {
   public Map<String, String> getEnrichmentAttrs() { return enrichmentAttrs; }
 
   /**
-   * @return Size in bytes of Event message and attributes.
+   * @return Size in bytes of Event message and attributes.  The size is memoized and should only be called once
+   * all Event fields are populated and will not be changed.
    */
   public int estimatedSerializedBytes() {
+    return estimatedSizeSupplier.get();
+  }
+
+  /**
+   * Memoize estimated event size
+   */
+  private Supplier<Integer> estimatedSizeSupplier = Suppliers.memoize(() -> estimatedSerializedBytesForMemoization());
+  private int estimatedSerializedBytesForMemoization() {
     int size = getMessage() == null ? 0 : getMessage().length();
     size += getTopic().length();
     size += EVENT_SERIALIZATION_OVERHEAD_BYTES;

--- a/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkConnectorConfig.java
+++ b/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkConnectorConfig.java
@@ -83,7 +83,7 @@ public class ScalyrSinkConnectorConfig extends AbstractConfig {
         .define(COMPRESSION_LEVEL_CONFIG, Type.INT, null, Importance.LOW, COMPRESSION_LEVEL_DOC)
         .define(ADD_EVENTS_TIMEOUT_MS_CONFIG, Type.INT, DEFAULT_ADD_EVENTS_TIMEOUT_MS, ConfigDef.Range.atLeast(2000), Importance.LOW, ADD_EVENTS_TIMEOUT_MS_DOC)
         .define(ADD_EVENTS_RETRY_DELAY_MS_CONFIG, Type.INT, DEFAULT_ADD_EVENTS_RETRY_DELAY_MS, ConfigDef.Range.atLeast(100), Importance.LOW, ADD_EVENTS_RETRY_DELAY_MS_DOC)
-        .define(BATCH_SEND_SIZE_BYTES_CONFIG, Type.INT, DEFAULT_BATCH_SEND_SIZE_BYTES, ConfigDef.Range.between(500_000, 6_000_000), Importance.LOW, BATCH_SEND_SIZE_BYTES_DOC)
+        .define(BATCH_SEND_SIZE_BYTES_CONFIG, Type.INT, DEFAULT_BATCH_SEND_SIZE_BYTES, ConfigDef.Range.between(500_000, 5_500_000), Importance.LOW, BATCH_SEND_SIZE_BYTES_DOC)
         .define(BATCH_SEND_WAIT_MS_CONFIG, Type.INT, DEFAULT_BATCH_SEND_WAIT_MS, ConfigDef.Range.atLeast(1000), Importance.LOW, BATCH_SEND_WAIT_MS_DOC)
         .define(CUSTOM_APP_EVENT_MAPPING_CONFIG, Type.STRING, null, customAppEventMappingValidator, Importance.MEDIUM, CUSTOM_APP_EVENT_MAPPING_DOC);
   }

--- a/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkTask.java
+++ b/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkTask.java
@@ -251,6 +251,10 @@ public class ScalyrSinkTask extends SinkTask {
     if (!addEventsResponse.isSuccess()) {
       lastError = createConnectException(addEventsResponse);
     }
+
+    if (addEventsResponse.hasIgnorableError()) {
+      log.warn("AddEventResponse with ignorable error {}", addEventsResponse);
+    }
   }
 
   /**

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -251,6 +251,16 @@ public class AddEventsClientTest {
     assertEquals(++requestCount, server.getRequestCount());
     assertEquals(0, mockSleep.sleepTime.get());
 
+    // Input too long
+    mockSleep.reset();
+    server.enqueue(new MockResponse().setResponseCode(200).setBody(ADD_EVENTS_RESPONSE_INPUT_TOO_LONG));
+    addEventsResponse = addEventsClient.log(createTestEvents(1, 1, 1, 1)).get(5, TimeUnit.SECONDS);
+    assertTrue(addEventsResponse.isSuccess());
+    assertTrue(addEventsResponse.hasIgnorableError());
+    assertFalse(addEventsResponse.isRetriable());
+    assertEquals(++requestCount, server.getRequestCount());
+    assertEquals(0, mockSleep.sleepTime.get());
+
     // Empty Response
     mockSleep.reset();
     TestUtils.addMockResponseWithRetries(server, new MockResponse().setResponseCode(200).setBody(""));

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -35,6 +35,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -391,6 +392,41 @@ public class AddEventsClientTest {
       testSingleRequestWithCompression();
     });
   }
+
+  /**
+   * Verify Add Events Requests that exceed maximum add events payload size are not sent.
+   */
+  @Test
+  public void testTooLargeAddEventsSkipped() throws Exception {
+    final int numEvents = 6;
+    final byte[] largeMsgBytes = new byte[1000000];
+    Arrays.fill(largeMsgBytes, (byte)'a');
+    final String largeMsg = new String(largeMsgBytes);
+
+    // Setup Mock Server
+    server.enqueue(new MockResponse().setResponseCode(200).setBody(ADD_EVENTS_RESPONSE_SUCCESS));
+
+    // Create addEvents request
+    AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor);
+    List<Event> events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
+    events.forEach(event -> event.setMessage(largeMsg));
+    addEventsClient.log(events);
+
+    // request should be skipped
+    assertEquals(0, server.getRequestCount());
+
+    // Send next batch that is smaller than max payload size
+    events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
+    addEventsClient.log(events);
+
+    // Verify request
+    ObjectMapper objectMapper = new ObjectMapper();
+    RecordedRequest request = server.takeRequest();
+    Map<String, Object> parsedEvents = objectMapper.readValue(request.getBody().inputStream(), Map.class);
+    validateEvents(events, parsedEvents);
+    verifyHeaders(request.getHeaders());
+  }
+
 
   /**
    * Create a single addEvents Request and verify the request body and header

--- a/src/test/java/com/scalyr/integrations/kafka/TestValues.java
+++ b/src/test/java/com/scalyr/integrations/kafka/TestValues.java
@@ -54,6 +54,7 @@ public abstract class TestValues {
   public static final String ADD_EVENTS_RESPONSE_SUCCESS;
   public static final String ADD_EVENTS_RESPONSE_SERVER_BUSY;
   public static final String ADD_EVENTS_RESPONSE_CLIENT_BAD_PARAM;
+  public static final String ADD_EVENTS_RESPONSE_INPUT_TOO_LONG;
   public static final String CUSTOM_APP_EVENT_MAPPING_JSON;
   public static final String CUSTOM_APP_EVENT_MAPPING_WITH_DELIMITER_JSON;
 
@@ -68,6 +69,8 @@ public abstract class TestValues {
         .setStatus("error/server/busy").setMessage("Requests are throttled.  Try again later"));
       ADD_EVENTS_RESPONSE_CLIENT_BAD_PARAM = objectMapper.writeValueAsString(new AddEventsClient.AddEventsResponse()
         .setStatus("error/client/badParam").setMessage("Maybe caused by bad api key"));
+      ADD_EVENTS_RESPONSE_INPUT_TOO_LONG = objectMapper.writeValueAsString(new AddEventsClient.AddEventsResponse()
+        .setStatus("error/client/badParam").setMessage("input too long (maximum 6000000 characters)"));
 
       CUSTOM_APP_EVENT_MAPPING_JSON = objectMapper.writeValueAsString(Collections.singletonList(createCustomAppEventMapping(".")));
       CUSTOM_APP_EVENT_MAPPING_WITH_DELIMITER_JSON = objectMapper.writeValueAsString(Collections.singletonList(createCustomAppEventMapping("_")));


### PR DESCRIPTION
We are seeing add events requests > 6 MB.  This may be caused by:
1. Single Event > 6 MB.  This may be possible because we do not truncate/split event attributes.
2. Event batch size code is underestimating batch size.

We currently stop the Kafka connector tasks when this error occurs.

Made the following changes:
1. Instead of stopping the Kafka connector task when add event requests exceed 6 MB, we skip these add event requests and log when this occurs.  Up to one too large add events request payload will be logged every 15 minutes.  Skipping too large add event requests may will result in log loss, but prevents the task from stopping and allows other logs to be sent.  The logging will help us determine the root cause of why the add events request exceed 6 MB.
2. Memoized the result of the event estimated size.  We size is needed twice - 1) before adding to the buffer to determine if adding this event to the buffer would cause the buffer send size to be exceeded and 2) When adding the event to the buffer.

This is an interim fix to allow add event batches > 6 MB to not stop the connector task and allows us to gather additional info for root cause analysis.