### PR TITLE
Take into account raw serialized pre-compression payload size when checking the request size limit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,16 @@
             <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+           <groupId>org.slf4j</groupId>
+           <artifactId>slf4j-api</artifactId>
+           <version>1.7.5</version>
+        </dependency>
+        <dependency>
+           <groupId>org.slf4j</groupId>
+           <artifactId>slf4j-log4j12</artifactId>
+           <version>1.7.5</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
+++ b/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
@@ -157,9 +157,7 @@ public class AddEventsClient implements AutoCloseable {
       outputStream.reset();
 
       // NOTE: We use countingStream since we also need access to the raw serialized payload size before the compression
-      OutputStream compressorStream = compressor.newStreamCompressor(outputStream);
-      CountingOutputStream countingStream = new CountingOutputStream(compressorStream);
-
+      CountingOutputStream countingStream = new CountingOutputStream(compressor.newStreamCompressor(outputStream));
       addEventsRequest.writeJson(countingStream);
 
       long rawPayloadSize = countingStream.getCount();

--- a/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
+++ b/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
@@ -200,7 +200,7 @@ public class AddEventsClient implements AutoCloseable {
     // 6 MB add events payload exceeded.  Log the issue and skip this message.
     if (rawPayloadSize > MAX_ADD_EVENTS_PAYLOAD_BYTES || addEventsPayload.length > MAX_ADD_EVENTS_PAYLOAD_BYTES) {
       // NOTE: compressed size should never really be larger than uncompressed size unless there is a pathological case
-      log.error("Add events payload size {} exceeds maximum size.  Skipping this add events request.  Log data will be lost", addEventsPayload.length);
+      log.error("Uncompressed add events payload size {} (compressed {}) exceeds maximum size.  Skipping this add events request.  Log data will be lost", rawPayloadSize, addEventsPayload.length);
       if (payloadTooLargeLogRateLimiter.tryAcquire()) {
         log.error("Add events too large payload: {}", new String(addEventsPayload));
       }

--- a/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
+++ b/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
@@ -199,8 +199,8 @@ public class AddEventsClient implements AutoCloseable {
     if (uncompressedPayloadSize > MAX_ADD_EVENTS_PAYLOAD_BYTES || addEventsPayload.length > MAX_ADD_EVENTS_PAYLOAD_BYTES) {
       // NOTE: compressed size should never really be larger than uncompressed size unless there is a pathological case
       // and we are trying to compress fully random uncompressable data
-      log.error("Uncompressed add events payload size {} (compressed {}) exceeds maximum size.  Skipping this add events request.  Log data will be lost",
-        uncompressedPayloadSize, addEventsPayload.length);
+      log.error("Uncompressed add events payload size {} bytes (compressed {} bytes) exceeds maximum size ({} bytes).  Skipping this add events request.  Log data will be lost",
+        uncompressedPayloadSize, addEventsPayload.length, MAX_ADD_EVENTS_PAYLOAD_BYTES);
       if (payloadTooLargeLogRateLimiter.tryAcquire()) {
         log.error("Add events too large payload: {}", new String(addEventsPayload));
       }

--- a/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
+++ b/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
@@ -156,9 +156,9 @@ public class AddEventsClient implements AutoCloseable {
 
       outputStream.reset();
 
-      // NOTE: We use countingStream since we also need access to the raw serialized payload size before compression
+      // NOTE: We use countingStream since we also need access to the raw serialized payload size before the compression
       OutputStream compressorStream = compressor.newStreamCompressor(outputStream);
-      CountingOutputStream countingStream = new CountingOutputStream(compressorStream);// NOTE: compressed size should never really be larger than uncompressed size unless there is a pathological case
+      CountingOutputStream countingStream = new CountingOutputStream(compressorStream);
 
       addEventsRequest.writeJson(countingStream);
 
@@ -200,6 +200,7 @@ public class AddEventsClient implements AutoCloseable {
     // 6 MB add events payload exceeded.  Log the issue and skip this message.
     if (rawPayloadSize > MAX_ADD_EVENTS_PAYLOAD_BYTES || addEventsPayload.length > MAX_ADD_EVENTS_PAYLOAD_BYTES) {
       // NOTE: compressed size should never really be larger than uncompressed size unless there is a pathological case
+      // and we are trying to compress fully random uncompressable data
       log.error("Uncompressed add events payload size {} (compressed {}) exceeds maximum size.  Skipping this add events request.  Log data will be lost", rawPayloadSize, addEventsPayload.length);
       if (payloadTooLargeLogRateLimiter.tryAcquire()) {
         log.error("Add events too large payload: {}", new String(addEventsPayload));

--- a/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
+++ b/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
@@ -294,7 +294,7 @@ public class AddEventsClient implements AutoCloseable {
    * @return Decompressed payload byte array.
    */
   @VisibleForTesting
-  protected byte[] getDecompressedPayload(byte[] addEventsPayload) {
+  byte[] getDecompressedPayload(byte[] addEventsPayload) {
     byte[] decompressedPayload = "unable to decompress the payload".getBytes();
     try {
       try (InputStream inputStream = compressor.newStreamDecompressor(new ByteArrayInputStream(addEventsPayload))) {

--- a/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
+++ b/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.CountingOutputStream;
@@ -295,7 +296,8 @@ public class AddEventsClient implements AutoCloseable {
    * @param addEventsPayload  byte[] addEvents payload (post compression if compression is enabled).
    * @return Decompressed payload byte array.
    */
-  private byte[] getDecompressedPayload(byte[] addEventsPayload) {
+  @VisibleForTesting
+  protected byte[] getDecompressedPayload(byte[] addEventsPayload) {
     byte[] decompressedPayload = "unable to decompress the payload".getBytes();
     try {
       try (InputStream inputStream = compressor.newStreamDecompressor(new ByteArrayInputStream(addEventsPayload))) {

--- a/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
+++ b/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
@@ -117,7 +117,7 @@ public class AddEventsClient implements AutoCloseable {
    * Limit number of add events payloads that are logged when MAX_ADD_EVENTS_PAYLOAD_BYTES is exceeded
    * TODO: Make this configurable
    */
-  private static final RateLimiter payloadTooLargeLogRateLimiter = RateLimiter.create( 1.0 / 900);  // 1 permit every 15 minutes
+  private static final RateLimiter payloadTooLargeLogRateLimiter = RateLimiter.create(1.0/900);  // 1 permit every 15 minutes
 
   /**
    * AddEventsClient which allows a mockable sleep for testing.

--- a/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
+++ b/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
@@ -297,17 +297,12 @@ public class AddEventsClient implements AutoCloseable {
    */
   private byte[] getDecompressedPayload(byte[] addEventsPayload) {
     byte[] decompressedPayload = "unable to decompress the payload".getBytes();
-    InputStream inputStream = compressor.newStreamDecompressor(new ByteArrayInputStream(addEventsPayload));
-
     try {
-      decompressedPayload = IOUtils.readAllBytes(inputStream);
+      try (InputStream inputStream = compressor.newStreamDecompressor(new ByteArrayInputStream(addEventsPayload))) {
+        decompressedPayload = IOUtils.readAllBytes(inputStream);
+      }
     } catch (Exception ex) {
       // NOTE: Failing to decompress the payload should not be fatal
-    }
-    finally {
-      try {
-        inputStream.close();
-      } catch (IOException e) {}
     }
 
     return decompressedPayload;

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -468,7 +468,7 @@ public class AddEventsClientTest {
     server.enqueue(new MockResponse().setResponseCode(200).setBody(ADD_EVENTS_RESPONSE_SUCCESS));
 
     // Create addEvents request
-    AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, this.deflateCompressor);
+    AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, deflateCompressor);
     List<Event> events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
     events.forEach(event -> event.setMessage(largeMsg));
 
@@ -493,9 +493,9 @@ public class AddEventsClientTest {
     // Verify request
     ObjectMapper objectMapper = new ObjectMapper();
     RecordedRequest request = server.takeRequest();
-    Map<String, Object> parsedEvents = objectMapper.readValue(this.deflateCompressor.newStreamDecompressor(request.getBody().inputStream()), Map.class);
+    Map<String, Object> parsedEvents = objectMapper.readValue(deflateCompressor.newStreamDecompressor(request.getBody().inputStream()), Map.class);
     validateEvents(events, parsedEvents);
-    verifyHeaders(request.getHeaders(), this.deflateCompressor);
+    verifyHeaders(request.getHeaders(), deflateCompressor);
   }
 
   /**

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -26,19 +26,19 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.apache.http.entity.ContentType;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import sun.misc.IOUtils;
-import sun.nio.ch.IOUtil;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -100,6 +100,9 @@ public class AddEventsClientTest {
     scalyrUrl = server.url("/").toString();
     this.compressor = CompressorFactory.getCompressor(CompressorFactory.NONE, null);
     this.deflateCompressor = CompressorFactory.getCompressor(CompressorFactory.DEFLATE, 3);
+
+    // We disable payload logging so we don't get very large raw payload messages in the log output
+    LogManager.getLogger("com.scalyr.integrations.kafka.eventpayload").setLevel(Level.OFF);
   }
 
   @After
@@ -425,7 +428,6 @@ public class AddEventsClientTest {
 
     // Create addEvents request
     AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor);
-    addEventsClient.logEventPayloadsOnPayloadTooLarge = false;
     List<Event> events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
     events.forEach(event -> event.setMessage(largeMsg));
 
@@ -474,7 +476,6 @@ public class AddEventsClientTest {
 
     // Create addEvents request
     AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, deflateCompressor);
-    addEventsClient.logEventPayloadsOnPayloadTooLarge = false;
     List<Event> events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
     events.forEach(event -> event.setMessage(largeMsg));
 

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -427,7 +427,7 @@ public class AddEventsClientTest {
     assertEquals(0, server.getRequestCount());
 
     AddEventsResponse addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);;
-    assertEquals("success", addEventsResponse.getStatus());
+    assertEquals(AddEventsResponse.SUCCESS, addEventsResponse.getStatus());
     assertEquals("Skipped due to payload too large", addEventsResponse.getMessage());
 
     // request should be skipped
@@ -436,7 +436,7 @@ public class AddEventsClientTest {
     // Send next batch that is smaller than max payload size
     events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
     addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);
-    assertEquals("success", addEventsResponse.getStatus());
+    assertEquals(AddEventsResponse.SUCCESS, addEventsResponse.getStatus());
     assertEquals("success", addEventsResponse.getMessage());
 
     // request should succeed
@@ -475,7 +475,7 @@ public class AddEventsClientTest {
     assertEquals(0, server.getRequestCount());
 
     AddEventsResponse addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);;
-    assertEquals("success", addEventsResponse.getStatus());
+    assertEquals(AddEventsResponse.SUCCESS, addEventsResponse.getStatus());
     assertEquals("Skipped due to payload too large", addEventsResponse.getMessage());
 
     // request should be skipped
@@ -484,7 +484,7 @@ public class AddEventsClientTest {
     // Send next batch that is smaller than max payload size
     events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
     addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);;
-    assertEquals("success", addEventsResponse.getStatus());
+    assertEquals(AddEventsResponse.SUCCESS, addEventsResponse.getStatus());
     assertEquals("success", addEventsResponse.getMessage());
 
     // request should succeed

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -420,6 +420,7 @@ public class AddEventsClientTest {
 
     // Create addEvents request
     AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor);
+    addEventsClient.logEventPayloadsOnPayloadTooLarge = false;
     List<Event> events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
     events.forEach(event -> event.setMessage(largeMsg));
 
@@ -467,6 +468,7 @@ public class AddEventsClientTest {
 
     // Create addEvents request
     AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, deflateCompressor);
+    addEventsClient.logEventPayloadsOnPayloadTooLarge = false;
     List<Event> events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
     events.forEach(event -> event.setMessage(largeMsg));
 

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -414,7 +414,6 @@ public class AddEventsClientTest {
     final byte[] largeMsgBytes = new byte[1000000];
     Arrays.fill(largeMsgBytes, (byte)'a');
     final String largeMsg = new String(largeMsgBytes);
-    AddEventsResponse addEventsResponse;
 
     // Setup Mock Server
     server.enqueue(new MockResponse().setResponseCode(200).setBody(ADD_EVENTS_RESPONSE_SUCCESS));
@@ -426,7 +425,7 @@ public class AddEventsClientTest {
 
     assertEquals(0, server.getRequestCount());
 
-    addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);
+    AddEventsResponse addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);;
     assertEquals("success", addEventsResponse.getStatus());
     assertEquals("Skipped due to payload too large", addEventsResponse.getMessage());
 
@@ -462,7 +461,6 @@ public class AddEventsClientTest {
     final byte[] largeMsgBytes = new byte[1000000];
     Arrays.fill(largeMsgBytes, (byte)'a');
     final String largeMsg = new String(largeMsgBytes);
-    AddEventsResponse addEventsResponse;
 
     // Setup Mock Server
     server.enqueue(new MockResponse().setResponseCode(200).setBody(ADD_EVENTS_RESPONSE_SUCCESS));
@@ -474,7 +472,7 @@ public class AddEventsClientTest {
 
     assertEquals(0, server.getRequestCount());
 
-    addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);;
+    AddEventsResponse addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);;
     assertEquals("success", addEventsResponse.getStatus());
     assertEquals("Skipped due to payload too large", addEventsResponse.getMessage());
 

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -427,6 +427,8 @@ public class AddEventsClientTest {
     assertEquals(0, server.getRequestCount());
 
     addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);
+    assertEquals(addEventsResponse.getStatus(), "success");
+    assertEquals(addEventsResponse.getMessage(), "Skipped due to payload too large");
 
     // request should be skipped
     assertEquals(0, server.getRequestCount());
@@ -434,6 +436,8 @@ public class AddEventsClientTest {
     // Send next batch that is smaller than max payload size
     events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
     addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);
+    assertEquals(addEventsResponse.getStatus(), "success");
+    assertEquals(addEventsResponse.getMessage(), "success");
 
     // request should succeed
     assertEquals(1, server.getRequestCount());
@@ -445,7 +449,6 @@ public class AddEventsClientTest {
     validateEvents(events, parsedEvents);
     verifyHeaders(request.getHeaders());
   }
-
 
   /**
    * Verify Add Events Requests that exceed maximum add events payload size before compression are not sent.
@@ -472,6 +475,8 @@ public class AddEventsClientTest {
     assertEquals(0, server.getRequestCount());
 
     addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);;
+    assertEquals(addEventsResponse.getStatus(), "success");
+    assertEquals(addEventsResponse.getMessage(), "Skipped due to payload too large");
 
     // request should be skipped
     assertEquals(0, server.getRequestCount());
@@ -479,6 +484,8 @@ public class AddEventsClientTest {
     // Send next batch that is smaller than max payload size
     events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
     addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);;
+    assertEquals(addEventsResponse.getStatus(), "success");
+    assertEquals(addEventsResponse.getMessage(), "success");
 
     // request should succeed
     assertEquals(1, server.getRequestCount());

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -432,7 +432,7 @@ public class AddEventsClientTest {
     assertEquals(0, server.getRequestCount());
 
     CompletableFuture<AddEventsResponse> initialAddEventsResponseFuture = addEventsClient.log(events);
-    AddEventsResponse initialAddEventsResponse = initialAddEventsResponseFuture.get(5, TimeUnit.SECONDS);;
+    AddEventsResponse initialAddEventsResponse = initialAddEventsResponseFuture.get(5, TimeUnit.SECONDS);
     assertEquals(AddEventsResponse.SUCCESS, initialAddEventsResponse.getStatus());
     assertEquals("Skipped due to payload too large", initialAddEventsResponse.getMessage());
 
@@ -481,7 +481,7 @@ public class AddEventsClientTest {
     assertEquals(0, server.getRequestCount());
 
     CompletableFuture<AddEventsResponse> initialAddEventsResponseFuture = addEventsClient.log(events);
-    AddEventsResponse initialAddEventsResponse = initialAddEventsResponseFuture.get(5, TimeUnit.SECONDS);;
+    AddEventsResponse initialAddEventsResponse = initialAddEventsResponseFuture.get(5, TimeUnit.SECONDS);
     assertEquals(AddEventsResponse.SUCCESS, initialAddEventsResponse.getStatus());
     assertEquals("Skipped due to payload too large", initialAddEventsResponse.getMessage());
 
@@ -490,7 +490,7 @@ public class AddEventsClientTest {
 
     // Send next batch that is smaller than max payload size
     events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
-    AddEventsResponse addEventsResponse = addEventsClient.log(events, initialAddEventsResponseFuture).get(5, TimeUnit.SECONDS);;
+    AddEventsResponse addEventsResponse = addEventsClient.log(events, initialAddEventsResponseFuture).get(5, TimeUnit.SECONDS);
     assertEquals(AddEventsResponse.SUCCESS, addEventsResponse.getStatus());
     assertEquals("success", addEventsResponse.getMessage());
 

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -426,16 +426,17 @@ public class AddEventsClientTest {
 
     assertEquals(0, server.getRequestCount());
 
-    AddEventsResponse addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);;
-    assertEquals(AddEventsResponse.SUCCESS, addEventsResponse.getStatus());
-    assertEquals("Skipped due to payload too large", addEventsResponse.getMessage());
+    CompletableFuture<AddEventsResponse> initialAddEventsResponseFuture = addEventsClient.log(events);
+    AddEventsResponse initialAddEventsResponse = initialAddEventsResponseFuture.get(5, TimeUnit.SECONDS);;
+    assertEquals(AddEventsResponse.SUCCESS, initialAddEventsResponse.getStatus());
+    assertEquals("Skipped due to payload too large", initialAddEventsResponse.getMessage());
 
     // request should be skipped
     assertEquals(0, server.getRequestCount());
 
     // Send next batch that is smaller than max payload size
     events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
-    addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);
+    AddEventsResponse addEventsResponse = addEventsClient.log(events, initialAddEventsResponseFuture).get(5, TimeUnit.SECONDS);
     assertEquals(AddEventsResponse.SUCCESS, addEventsResponse.getStatus());
     assertEquals("success", addEventsResponse.getMessage());
 
@@ -474,16 +475,17 @@ public class AddEventsClientTest {
 
     assertEquals(0, server.getRequestCount());
 
-    AddEventsResponse addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);;
-    assertEquals(AddEventsResponse.SUCCESS, addEventsResponse.getStatus());
-    assertEquals("Skipped due to payload too large", addEventsResponse.getMessage());
+    CompletableFuture<AddEventsResponse> initialAddEventsResponseFuture = addEventsClient.log(events);
+    AddEventsResponse initialAddEventsResponse = initialAddEventsResponseFuture.get(5, TimeUnit.SECONDS);;
+    assertEquals(AddEventsResponse.SUCCESS, initialAddEventsResponse.getStatus());
+    assertEquals("Skipped due to payload too large", initialAddEventsResponse.getMessage());
 
     // request should be skipped
     assertEquals(0, server.getRequestCount());
 
     // Send next batch that is smaller than max payload size
     events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
-    addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);;
+    AddEventsResponse addEventsResponse = addEventsClient.log(events, initialAddEventsResponseFuture).get(5, TimeUnit.SECONDS);;
     assertEquals(AddEventsResponse.SUCCESS, addEventsResponse.getStatus());
     assertEquals("success", addEventsResponse.getMessage());
 

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -426,14 +426,14 @@ public class AddEventsClientTest {
 
     assertEquals(0, server.getRequestCount());
 
-    addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);;
+    addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);
 
     // request should be skipped
     assertEquals(0, server.getRequestCount());
 
     // Send next batch that is smaller than max payload size
     events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
-    addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);;
+    addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);
 
     // request should succeed
     assertEquals(1, server.getRequestCount());
@@ -449,6 +449,9 @@ public class AddEventsClientTest {
 
   /**
    * Verify Add Events Requests that exceed maximum add events payload size before compression are not sent.
+   *
+   * In this scenario we test a request which is larger than 6 MB before compression, but smaller than 6 MB
+   * after compression.
    */
   @Test
   public void testTooLargeAddEventsSkippedDeflateCompressedRequest() throws Exception {
@@ -483,6 +486,8 @@ public class AddEventsClientTest {
     // Verify request
     ObjectMapper objectMapper = new ObjectMapper();
     RecordedRequest request = server.takeRequest();
+    Map<String, Object> parsedEvents = objectMapper.readValue(this.deflateCompressor.newStreamDecompressor(request.getBody().inputStream()), Map.class);
+    validateEvents(events, parsedEvents);
     verifyHeaders(request.getHeaders(), this.deflateCompressor);
   }
 

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -427,8 +427,8 @@ public class AddEventsClientTest {
     assertEquals(0, server.getRequestCount());
 
     addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);
-    assertEquals(addEventsResponse.getStatus(), "success");
-    assertEquals(addEventsResponse.getMessage(), "Skipped due to payload too large");
+    assertEquals("success", addEventsResponse.getStatus());
+    assertEquals("Skipped due to payload too large", addEventsResponse.getMessage());
 
     // request should be skipped
     assertEquals(0, server.getRequestCount());
@@ -436,8 +436,8 @@ public class AddEventsClientTest {
     // Send next batch that is smaller than max payload size
     events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
     addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);
-    assertEquals(addEventsResponse.getStatus(), "success");
-    assertEquals(addEventsResponse.getMessage(), "success");
+    assertEquals("success", addEventsResponse.getStatus());
+    assertEquals("success", addEventsResponse.getMessage());
 
     // request should succeed
     assertEquals(1, server.getRequestCount());
@@ -475,8 +475,8 @@ public class AddEventsClientTest {
     assertEquals(0, server.getRequestCount());
 
     addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);;
-    assertEquals(addEventsResponse.getStatus(), "success");
-    assertEquals(addEventsResponse.getMessage(), "Skipped due to payload too large");
+    assertEquals("success", addEventsResponse.getStatus());
+    assertEquals("Skipped due to payload too large", addEventsResponse.getMessage());
 
     // request should be skipped
     assertEquals(0, server.getRequestCount());
@@ -484,8 +484,8 @@ public class AddEventsClientTest {
     // Send next batch that is smaller than max payload size
     events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
     addEventsResponse = addEventsClient.log(events).get(5, TimeUnit.SECONDS);;
-    assertEquals(addEventsResponse.getStatus(), "success");
-    assertEquals(addEventsResponse.getMessage(), "success");
+    assertEquals("success", addEventsResponse.getStatus());
+    assertEquals("success", addEventsResponse.getMessage());
 
     // request should succeed
     assertEquals(1, server.getRequestCount());

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.logger.com.scalyr.integrations.kafka=DEBUG, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
This pull request updates the code to take into account the size of the raw JSON serialized AddEvents payload when determining if the request payload will hit the max request size limit (6 MB).

This way the behavior is in sync with the server side behavior - server side takes raw uncompressed payload size into account. Previously code in this library took into account compressed payload size and that's why it didn't work as expected.

In addition to that, I noticed that some of the existing tests are incorrect / broken since we never execute / run the future and we don't have enough assertions in place to catch that - I'm working on a fix + additional test case for this scenario.