### PR TITLE
Improve accuracy of EventBuffer estimatedSerializedBytes

### DIFF
--- a/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
+++ b/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.io.ByteStreams;
 import com.google.common.io.CountingOutputStream;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -40,7 +41,6 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.misc.IOUtils;
 
 import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
@@ -298,7 +298,7 @@ public class AddEventsClient implements AutoCloseable {
     byte[] decompressedPayload = "unable to decompress the payload".getBytes();
     try {
       try (InputStream inputStream = compressor.newStreamDecompressor(new ByteArrayInputStream(addEventsPayload))) {
-        decompressedPayload = IOUtils.readAllBytes(inputStream);
+        decompressedPayload = ByteStreams.toByteArray(inputStream);
       }
     } catch (Exception ex) {
       // NOTE: Failing to decompress the payload should not be fatal

--- a/src/main/java/com/scalyr/integrations/kafka/Event.java
+++ b/src/main/java/com/scalyr/integrations/kafka/Event.java
@@ -224,7 +224,7 @@ public class Event {
 
   private int countJsonEscapedCharacters(String s) {
     return (int)IntStream.range(0, s.length())
-      .mapToObj(i -> s.charAt(i))
+      .mapToObj(s::charAt)
       .filter(JSON_ESCAPED_CHARS::contains)
       .count();
   }

--- a/src/main/java/com/scalyr/integrations/kafka/EventBuffer.java
+++ b/src/main/java/com/scalyr/integrations/kafka/EventBuffer.java
@@ -1,0 +1,69 @@
+package com.scalyr.integrations.kafka;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Buffer for Events to send larger addEvents batch size.
+ * Includes estimation of serialized AddEvent payload bytes.
+ */
+public class EventBuffer {
+  private final List<Event> eventBuffer = new ArrayList<>(2000);
+  private final AtomicInteger estimatedSerializedBytes = new AtomicInteger();
+  // Unique session attributes used for estimating serialized bytes
+  private final Set<String> sessionAttributes = new HashSet<>();
+
+  public void addEvent(Event event) {
+    eventBuffer.add(event);
+    estimatedSerializedBytes.addAndGet(event.estimatedSerializedBytes());
+    updateSessionAttrSize(event);
+  }
+
+  /**
+   * @return Number of events
+   */
+  public int length() {
+    return eventBuffer.size();
+  }
+
+  /**
+   * @return Estimated serialized bytes of event messages and attributes
+   */
+  public int estimatedSerializedBytes() {
+    return estimatedSerializedBytes.get();
+  }
+
+  /**
+   * @return Buffered Events
+   */
+  public List<Event> getEvents() {
+    return eventBuffer;
+  }
+
+  /**
+   * Clears the event buffer
+   */
+  public void clear() {
+    eventBuffer.clear();
+    sessionAttributes.clear();
+    estimatedSerializedBytes.set(0);
+  }
+
+  /**
+   * Update estimated msgSize with session attributes
+   */
+  private void updateSessionAttrSize(Event event) {
+    updateSessionAttrSize(event.getLogfile());
+    updateSessionAttrSize(event.getParser());
+    updateSessionAttrSize(event.getServerHost());
+  }
+
+  private void updateSessionAttrSize(String sessionAttr) {
+    if (sessionAttributes.add(sessionAttr)) {
+      estimatedSerializedBytes.addAndGet(sessionAttr.length());
+    }
+  }
+}

--- a/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkTask.java
+++ b/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkTask.java
@@ -32,17 +32,13 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.LongConsumer;
 import java.util.stream.Collectors;
 
@@ -301,68 +297,6 @@ public class ScalyrSinkTask extends SinkTask {
       return CustomAppEventMapping.parseCustomAppEventMappingConfig(customAppEventMappingJson);
     } catch (IOException e) {
       throw new RuntimeException(e);
-    }
-  }
-
-  /**
-   * Buffer for Events to send larger addEvents batch size.
-   * Includes estimation of serialized AddEvent payload bytes.
-   */
-  private static class EventBuffer {
-    private final List<Event> eventBuffer = new ArrayList<>(2000);
-    private final AtomicInteger estimatedSerializedBytes = new AtomicInteger();
-    // Unique session attributes used for estimating serialized bytes
-    private final Set<String> sessionAttributes = new HashSet<>();
-
-    public void addEvent(Event event) {
-      eventBuffer.add(event);
-      estimatedSerializedBytes.addAndGet(event.estimatedSerializedBytes());
-      updateSessionAttrSize(event);
-    }
-
-    /**
-     * @return Number of events
-     */
-    public int length() {
-      return eventBuffer.size();
-    }
-
-    /**
-     * @return Estimated serialized bytes of event messages and attributes
-     */
-    public int estimatedSerializedBytes() {
-      return estimatedSerializedBytes.get();
-    }
-
-    /**
-     * @return Buffered Events
-     */
-    public List<Event> getEvents() {
-      return eventBuffer;
-    }
-
-    /**
-     * Clears the event buffer
-     */
-    public void clear() {
-      eventBuffer.clear();
-      sessionAttributes.clear();
-      estimatedSerializedBytes.set(0);
-    }
-
-    /**
-     * Update estimated msgSize with session attributes
-     */
-    private void updateSessionAttrSize(Event event) {
-      updateSessionAttrSize(event.getLogfile());
-      updateSessionAttrSize(event.getParser());
-      updateSessionAttrSize(event.getServerHost());
-    }
-
-    private void updateSessionAttrSize(String sessionAttr) {
-      if (sessionAttributes.add(sessionAttr)) {
-        estimatedSerializedBytes.addAndGet(sessionAttr.length());
-      }
     }
   }
 

--- a/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkTask.java
+++ b/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkTask.java
@@ -35,9 +35,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -304,14 +306,18 @@ public class ScalyrSinkTask extends SinkTask {
 
   /**
    * Buffer for Events to send larger addEvents batch size.
+   * Includes estimation of serialized AddEvent payload bytes.
    */
   private static class EventBuffer {
     private final List<Event> eventBuffer = new ArrayList<>(2000);
-    private final AtomicInteger msgSize = new AtomicInteger();
+    private final AtomicInteger estimatedSerializedBytes = new AtomicInteger();
+    // Unique session attributes used for estimating serialized bytes
+    private final Set<String> sessionAttributes = new HashSet<>();
 
     public void addEvent(Event event) {
       eventBuffer.add(event);
-      msgSize.addAndGet(event.estimatedSerializedBytes());
+      estimatedSerializedBytes.addAndGet(event.estimatedSerializedBytes());
+      updateSessionAttrSize(event);
     }
 
     /**
@@ -325,7 +331,7 @@ public class ScalyrSinkTask extends SinkTask {
      * @return Estimated serialized bytes of event messages and attributes
      */
     public int estimatedSerializedBytes() {
-      return msgSize.get();
+      return estimatedSerializedBytes.get();
     }
 
     /**
@@ -340,7 +346,23 @@ public class ScalyrSinkTask extends SinkTask {
      */
     public void clear() {
       eventBuffer.clear();
-      msgSize.set(0);
+      sessionAttributes.clear();
+      estimatedSerializedBytes.set(0);
+    }
+
+    /**
+     * Update estimated msgSize with session attributes
+     */
+    private void updateSessionAttrSize(Event event) {
+      updateSessionAttrSize(event.getLogfile());
+      updateSessionAttrSize(event.getParser());
+      updateSessionAttrSize(event.getServerHost());
+    }
+
+    private void updateSessionAttrSize(String sessionAttr) {
+      if (sessionAttributes.add(sessionAttr)) {
+        estimatedSerializedBytes.addAndGet(sessionAttr.length());
+      }
     }
   }
 

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -18,6 +18,7 @@ package com.scalyr.integrations.kafka;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.io.ByteStreams;
 import com.scalyr.api.internal.ScalyrUtil;
 import com.scalyr.integrations.kafka.AddEventsClient.AddEventsRequest;
 import com.scalyr.integrations.kafka.AddEventsClient.AddEventsResponse;
@@ -32,7 +33,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import sun.misc.IOUtils;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -502,7 +502,7 @@ public class AddEventsClientTest {
     RecordedRequest request = server.takeRequest();
 
     InputStream requestBodyInputStream = new BufferedInputStream(request.getBody().inputStream());
-    byte[] requestBody = IOUtils.readAllBytes(requestBodyInputStream);
+    byte[] requestBody = ByteStreams.toByteArray(requestBodyInputStream);
     byte[] decompressedRequestBody = addEventsClient.getDecompressedPayload(requestBody);
     Map<String, Object> parsedEvents = objectMapper.readValue(decompressedRequestBody, Map.class);
     validateEvents(events, parsedEvents);

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -43,7 +43,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -127,7 +126,7 @@ public class AddEventsClientTest {
    * and verify the AddEventsRequest is serialized correctly to JSON.
    */
   private void addEventsRequestTest(int numEvents, int numServers, int numLogFiles, int numParsers) throws IOException {
-    List<Event> events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
+    List<Event> events = TestUtils.createTestEvents(numEvents, numServers, numLogFiles, numParsers);
     createAndVerifyAddEventsRequest(events);
   }
 
@@ -197,7 +196,7 @@ public class AddEventsClientTest {
 
     // Create addEvents request
     AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor);
-    List<Event> events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
+    List<Event> events = TestUtils.createTestEvents(numEvents, numServers, numLogFiles, numParsers);
     addEventsClient.log(events);
 
     // Verify request
@@ -224,7 +223,7 @@ public class AddEventsClientTest {
     AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor);
     for (int i = 0; i < numRequests; i++) {
       // Create addEvents request
-      List<Event> events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
+      List<Event> events = TestUtils.createTestEvents(numEvents, numServers, numLogFiles, numParsers);
       addEventsClient.log(events);
 
       // Verify addEvents request
@@ -248,7 +247,7 @@ public class AddEventsClientTest {
 
     // Server Too Busy
     TestUtils.addMockResponseWithRetries(server, new MockResponse().setResponseCode(429).setBody(ADD_EVENTS_RESPONSE_SERVER_BUSY));
-    AddEventsResponse addEventsResponse = addEventsClient.log(createTestEvents(1, 1, 1, 1)).get(5, TimeUnit.SECONDS);
+    AddEventsResponse addEventsResponse = addEventsClient.log(TestUtils.createTestEvents(1, 1, 1, 1)).get(5, TimeUnit.SECONDS);
     assertEquals("serverTooBusy", addEventsResponse.getStatus());
     assertEquals(requestCount += EXPECTED_NUM_RETRIES, server.getRequestCount());
     assertEquals(EXPECTED_SLEEP_TIME_MS, mockSleep.sleepTime.get());
@@ -256,7 +255,7 @@ public class AddEventsClientTest {
     // Client Bad Request
     mockSleep.reset();
     server.enqueue(new MockResponse().setResponseCode(200).setBody(ADD_EVENTS_RESPONSE_CLIENT_BAD_PARAM));
-    addEventsResponse = addEventsClient.log(createTestEvents(1, 1, 1, 1)).get(5, TimeUnit.SECONDS);
+    addEventsResponse = addEventsClient.log(TestUtils.createTestEvents(1, 1, 1, 1)).get(5, TimeUnit.SECONDS);
     assertEquals(AddEventsResponse.CLIENT_BAD_PARAM, addEventsResponse.getStatus());
     assertEquals(++requestCount, server.getRequestCount());
     assertEquals(0, mockSleep.sleepTime.get());
@@ -264,7 +263,7 @@ public class AddEventsClientTest {
     // Input too long
     mockSleep.reset();
     server.enqueue(new MockResponse().setResponseCode(200).setBody(ADD_EVENTS_RESPONSE_INPUT_TOO_LONG));
-    addEventsResponse = addEventsClient.log(createTestEvents(1, 1, 1, 1)).get(5, TimeUnit.SECONDS);
+    addEventsResponse = addEventsClient.log(TestUtils.createTestEvents(1, 1, 1, 1)).get(5, TimeUnit.SECONDS);
     assertTrue(addEventsResponse.isSuccess());
     assertTrue(addEventsResponse.hasIgnorableError());
     assertFalse(addEventsResponse.isRetriable());
@@ -274,7 +273,7 @@ public class AddEventsClientTest {
     // Empty Response
     mockSleep.reset();
     TestUtils.addMockResponseWithRetries(server, new MockResponse().setResponseCode(200).setBody(""));
-    addEventsResponse = addEventsClient.log(createTestEvents(1, 1, 1, 1)).get(5, TimeUnit.SECONDS);
+    addEventsResponse = addEventsClient.log(TestUtils.createTestEvents(1, 1, 1, 1)).get(5, TimeUnit.SECONDS);
     assertEquals("emptyResponse", addEventsResponse.getStatus());
     assertEquals(requestCount + EXPECTED_NUM_RETRIES, server.getRequestCount());
     assertEquals(EXPECTED_SLEEP_TIME_MS, mockSleep.sleepTime.get());
@@ -283,7 +282,7 @@ public class AddEventsClientTest {
     // Doesn't actually hit MockHttpServer, so cannot advance MockableTimer.
     mockSleep.reset();
     addEventsClient = new AddEventsClient("http://localhost", API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor, mockSleep.sleep);
-    addEventsResponse = addEventsClient.log(createTestEvents(1, 1, 1, 1)).get(5, TimeUnit.MINUTES);
+    addEventsResponse = addEventsClient.log(TestUtils.createTestEvents(1, 1, 1, 1)).get(5, TimeUnit.MINUTES);
     assertEquals("IOException", addEventsResponse.getStatus());
     assertEquals(EXPECTED_SLEEP_TIME_MS, mockSleep.sleepTime.get());
   }
@@ -299,11 +298,11 @@ public class AddEventsClientTest {
     server.enqueue(new MockResponse().setResponseCode(200).setBody(ADD_EVENTS_RESPONSE_SUCCESS));
 
     // Send requests
-    List<Event> firstTestEvent = createTestEvents(1, 1, 1, 1);
+    List<Event> firstTestEvent = TestUtils.createTestEvents(1, 1, 1, 1);
     firstTestEvent.get(0).setMessage("First");
     CompletableFuture<AddEventsResponse> request1 = addEventsClient.log(firstTestEvent);
 
-    List<Event> secondTestEvent = createTestEvents(1, 1, 1, 1);
+    List<Event> secondTestEvent = TestUtils.createTestEvents(1, 1, 1, 1);
     secondTestEvent.get(0).setMessage("Second");
     CompletableFuture<AddEventsResponse> request2 = addEventsClient.log(secondTestEvent, request1);
 
@@ -346,8 +345,8 @@ public class AddEventsClientTest {
     TestUtils.addMockResponseWithRetries(server, new MockResponse().setResponseCode(429).setBody(ADD_EVENTS_RESPONSE_SERVER_BUSY));
     server.enqueue(new MockResponse().setResponseCode(200).setBody(ADD_EVENTS_RESPONSE_SUCCESS));
 
-    CompletableFuture<AddEventsResponse> request1 = addEventsClient.log(createTestEvents(1, 1, 1, 1));
-    CompletableFuture<AddEventsResponse> request2 = addEventsClient.log(createTestEvents(1, 1, 1, 1), request1);
+    CompletableFuture<AddEventsResponse> request1 = addEventsClient.log(TestUtils.createTestEvents(1, 1, 1, 1));
+    CompletableFuture<AddEventsResponse> request2 = addEventsClient.log(TestUtils.createTestEvents(1, 1, 1, 1), request1);
 
     AddEventsResponse addEventsResponse1 = request1.get(5, TimeUnit.SECONDS);
     AddEventsResponse addEventsResponse2 = request2.get(5, TimeUnit.SECONDS);
@@ -365,7 +364,7 @@ public class AddEventsClientTest {
     AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, 1, ADD_EVENTS_RETRY_DELAY_MS, compressor);
 
     CompletableFuture<AddEventsResponse> fakeSlowPendingRequest = new CompletableFuture<>();
-    CompletableFuture<AddEventsResponse> request2 = addEventsClient.log(createTestEvents(1, 1, 1, 1), fakeSlowPendingRequest);
+    CompletableFuture<AddEventsResponse> request2 = addEventsClient.log(TestUtils.createTestEvents(1, 1, 1, 1), fakeSlowPendingRequest);
     AddEventsResponse addEventsResponse2 = request2.get(5, TimeUnit.SECONDS);
     assertFalse(addEventsResponse2.isSuccess());
     assertTrue(addEventsResponse2.getMessage().contains("TimeoutException"));
@@ -382,7 +381,7 @@ public class AddEventsClientTest {
 
     // Server Too Busy
     TestUtils.addMockResponseWithRetries(server, new MockResponse().setResponseCode(429).setBody(ADD_EVENTS_RESPONSE_SERVER_BUSY));
-    AddEventsResponse addEventsResponse = addEventsClient.log(createTestEvents(1, 1, 1, 1)).get(ADD_EVENTS_TIMEOUT_MS, TimeUnit.SECONDS);
+    AddEventsResponse addEventsResponse = addEventsClient.log(TestUtils.createTestEvents(1, 1, 1, 1)).get(ADD_EVENTS_TIMEOUT_MS, TimeUnit.SECONDS);
     assertEquals("serverTooBusy", addEventsResponse.getStatus());
     assertEquals(EXPECTED_NUM_RETRIES, server.getRequestCount());
   }
@@ -428,7 +427,7 @@ public class AddEventsClientTest {
 
     // Create addEvents request
     AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor);
-    List<Event> events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
+    List<Event> events = TestUtils.createTestEvents(numEvents, numServers, numLogFiles, numParsers);
     events.forEach(event -> event.setMessage(largeMsg));
 
     assertEquals(0, server.getRequestCount());
@@ -442,7 +441,7 @@ public class AddEventsClientTest {
     assertEquals(0, server.getRequestCount());
 
     // Send next batch that is smaller than max payload size
-    events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
+    events = TestUtils.createTestEvents(numEvents, numServers, numLogFiles, numParsers);
     AddEventsResponse addEventsResponse = addEventsClient.log(events, initialAddEventsResponseFuture).get(5, TimeUnit.SECONDS);
     assertEquals(AddEventsResponse.SUCCESS, addEventsResponse.getStatus());
     assertEquals("success", addEventsResponse.getMessage());
@@ -476,7 +475,7 @@ public class AddEventsClientTest {
 
     // Create addEvents request
     AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, deflateCompressor);
-    List<Event> events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
+    List<Event> events = TestUtils.createTestEvents(numEvents, numServers, numLogFiles, numParsers);
     events.forEach(event -> event.setMessage(largeMsg));
 
     assertEquals(0, server.getRequestCount());
@@ -490,7 +489,7 @@ public class AddEventsClientTest {
     assertEquals(0, server.getRequestCount());
 
     // Send next batch that is smaller than max payload size
-    events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
+    events = TestUtils.createTestEvents(numEvents, numServers, numLogFiles, numParsers);
     AddEventsResponse addEventsResponse = addEventsClient.log(events, initialAddEventsResponseFuture).get(5, TimeUnit.SECONDS);
     assertEquals(AddEventsResponse.SUCCESS, addEventsResponse.getStatus());
     assertEquals("success", addEventsResponse.getMessage());
@@ -529,7 +528,7 @@ public class AddEventsClientTest {
 
       // Create addEvents request
       AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor);
-      List<Event> events = createTestEvents(numEvents, numServers, numLogFiles, numParsers);
+      List<Event> events = TestUtils.createTestEvents(numEvents, numServers, numLogFiles, numParsers);
       addEventsClient.log(events);
 
       // Verify request
@@ -560,33 +559,6 @@ public class AddEventsClientTest {
     assertEquals("Keep-Alive", headers.get("Connection"));
     assertEquals(expectedUserAgent, headers.get("User-Agent"));
     assertEquals(compressor.getContentEncoding(), headers.get("Content-Encoding"));
-  }
-
-  /**
-   * Create `numEvents` Events with the specified `numServers`, `numLogFiles`, and `numParsers` values.
-   */
-  private List<Event> createTestEvents(int numEvents, int numServers, int numLogFiles, int numParsers) {
-    assertTrue(numParsers <= numLogFiles);
-    Random random = new Random();
-    return IntStream.range(0, numEvents)
-      .boxed()
-      .map(i -> {
-        final int logFileNum = random.nextInt(numLogFiles);
-        return new Event()
-          .setTopic(TestValues.TOPIC_VALUE)
-          .setPartition(0)
-          .setOffset(i)
-          .setMessage(TestValues.MESSAGE_VALUE)
-          .setParser(TestValues.PARSER_VALUE + logFileNum % numParsers)
-          .setLogfile(TestValues.LOGFILE_VALUE + logFileNum)
-          .setServerHost(TestValues.SERVER_VALUE + random.nextInt(numServers))
-          .setTimestamp(ScalyrUtil.nanoTime())
-          .addAdditionalAttr("app", "test")
-          .addAdditionalAttr("isTest", true)
-          .addAdditionalAttr("version", 2.3)
-          .setEnrichmentAttrs(ENRICHMENT_VALUE_MAP);
-      })
-      .collect(Collectors.toList());
   }
 
   /**

--- a/src/test/java/com/scalyr/integrations/kafka/EventBufferTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/EventBufferTest.java
@@ -1,0 +1,75 @@
+package com.scalyr.integrations.kafka;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Verify EventBuffer add events payload estimates
+ */
+public class EventBufferTest {
+  // Acceptable margin of error for estimated vs actual add events payload size
+  private static final double deltaPercent = 0.05;
+
+  /**
+   * Test add events payload estimate with small event messages.
+   */
+  @Test
+  public void testSmallEventMsg() throws Exception {
+    final int numEvents = 30000;
+    final String smallMsg = "This is a small sixty-four byte message.  This is a small sixty-";
+    EventBuffer eventBuffer = new EventBuffer();
+    TestUtils.createTestEvents(numEvents, smallMsg, 100, 1, 1)
+      .forEach(eventBuffer::addEvent);
+
+    final int estimatedSerializedBytes = eventBuffer.estimatedSerializedBytes();
+    final int actualSerializedBytes = actualSerializedSize(eventBuffer.getEvents());
+    assertEquals(actualSerializedBytes, estimatedSerializedBytes, actualSerializedBytes * deltaPercent);
+  }
+
+  /**
+   * Test add events payload estimate with many server attributes
+   * Server attributes are: logfile, serverHost, and parser
+   */
+  @Test
+  public void testManyServerAttributes() throws Exception {
+    final int numEvents = 1000;
+    EventBuffer eventBuffer = new EventBuffer();
+    TestUtils.createTestEvents(numEvents, TestValues.MESSAGE_VALUE, 1000, 10, 10)
+      .forEach(eventBuffer::addEvent);
+
+    final int estimatedSerializedBytes = eventBuffer.estimatedSerializedBytes();
+    final int actualSerializedBytes = actualSerializedSize(eventBuffer.getEvents());
+    assertEquals(actualSerializedBytes, estimatedSerializedBytes, actualSerializedBytes * deltaPercent);
+  }
+
+  /**
+   * Test add events payload estimate with JSON event attributes.
+   */
+  @Test
+  public void testJsonEventMsg() throws Exception {
+    final int numEvents = 25000;
+    final String jsonMsg = "{\"k1\":\"v1\", \"k2\":\"v2\", \"k3\": 1.0, \"k4\": {\"k1\":\"v1\", \"k2\":\"v2\"}}";
+    EventBuffer eventBuffer = new EventBuffer();
+    TestUtils.createTestEvents(numEvents, jsonMsg, 100, 1, 1)
+      .forEach(eventBuffer::addEvent);
+
+    final int estimatedSerializedBytes = eventBuffer.estimatedSerializedBytes();
+    final int actualSerializedBytes = actualSerializedSize(eventBuffer.getEvents());
+    assertEquals(actualSerializedBytes, estimatedSerializedBytes, actualSerializedBytes * deltaPercent);
+  }
+
+  /**
+   * Calculate add events payload serialized size.
+   */
+  private int actualSerializedSize(List<Event> events) throws Exception {
+    AddEventsClient.AddEventsRequest addEventsRequest = new AddEventsClient.AddEventsRequest();
+    addEventsRequest.setEvents(events);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    addEventsRequest.writeJson(baos);
+    return baos.size();
+  }
+}


### PR DESCRIPTION
Inaccurate `EventBuffer. estimatedSerializedBytes` are causing the 6 MB add events payload limit to be exceeded.

Improve `EventBuffer. estimatedSerializedBytes` with the following changes:
1. More accurate per event overhead constant
2. Include server attributes in the estimatedSerializedBytes
3. Include String escaping for JSON strings in the estimatedSerializedBytes.

These changes indicate that the estimates are within 5% accuracy of the actual serialized payload.

Best to review by commit since I refactored `EventBuffer` to be its own top level class.  The crux of the changes are in the `Additional improvements for EventBuffer estimatedSerializedBytes` commit.  It's probably easiest to start from there and work backwards.  This commit also changed some of the changes in the first commit.  I typically would have rebased and combined the 1st and 3rd commits but refactoring the `EventBuffer` class made this difficult.