### PR TITLE
CT-195 Change `source` to `serverHost`

### DIFF
--- a/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
+++ b/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
@@ -456,7 +456,7 @@ public class AddEventsClient implements AutoCloseable {
       jsonGenerator.writeObjectFieldStart("attrs");
 
       if (event.getServerHost() != null) {
-        jsonGenerator.writeStringField("source", event.getServerHost());
+        jsonGenerator.writeStringField("serverHost", event.getServerHost());
       }
       if (event.getLogfile() != null) {
         jsonGenerator.writeStringField("logfile", event.getLogfile());

--- a/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
+++ b/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
@@ -458,6 +458,10 @@ public class AddEventsClient implements AutoCloseable {
       if (event.getServerHost() != null) {
         jsonGenerator.writeStringField("serverHost", event.getServerHost());
       }
+      // virtual session splitting uses source for the serverHost
+      if (event.getServerHost() != null) {
+        jsonGenerator.writeStringField("source", event.getServerHost());
+      }
       if (event.getLogfile() != null) {
         jsonGenerator.writeStringField("logfile", event.getLogfile());
       }

--- a/src/main/java/com/scalyr/integrations/kafka/EventBuffer.java
+++ b/src/main/java/com/scalyr/integrations/kafka/EventBuffer.java
@@ -21,8 +21,8 @@ public class EventBuffer {
   // Enrichment attrs are the same for all events, so we cache this
   private int cachedEnrichmentAttrSize = 0;
 
-  // Estimated per server attribute entry overhead: {"id":"999","attrs":{"source":"","logfile":"","parser":""}
-  private static final int SERVER_ATTR_SERIALIZATION_OVERHEAD_BYTES = 60;
+  // Estimated per server attribute entry overhead: {"id":"999","attrs":{"serverHost":"","logfile":"","parser":""}
+  private static final int SERVER_ATTR_SERIALIZATION_OVERHEAD_BYTES = 63;
 
   public void addEvent(Event event) {
     eventBuffer.add(event);

--- a/src/main/java/com/scalyr/integrations/kafka/EventBuffer.java
+++ b/src/main/java/com/scalyr/integrations/kafka/EventBuffer.java
@@ -21,8 +21,8 @@ public class EventBuffer {
   // Enrichment attrs are the same for all events, so we cache this
   private int cachedEnrichmentAttrSize = 0;
 
-  // Estimated per server attribute entry overhead: {"id":"999","attrs":{"serverHost":"","logfile":"","parser":""}
-  private static final int SERVER_ATTR_SERIALIZATION_OVERHEAD_BYTES = 63;
+  // Estimated per server attribute entry overhead: {"id":"999","attrs":{"serverHost":"","source":"","logfile":"","parser":""}
+  private static final int SERVER_ATTR_SERIALIZATION_OVERHEAD_BYTES = 75;
 
   public void addEvent(Event event) {
     eventBuffer.add(event);
@@ -67,7 +67,8 @@ public class EventBuffer {
     if (serverAttributes.add(event)) {
       updateServerAttrSize(event.getLogfile());
       updateServerAttrSize(event.getParser());
-      updateServerAttrSize(event.getServerHost());
+      updateServerAttrSize(event.getServerHost());  // serverHost as serverHost
+      updateServerAttrSize(event.getServerHost());  // serverHost as source
       estimatedSerializedBytes.addAndGet(SERVER_ATTR_SERIALIZATION_OVERHEAD_BYTES);
       estimatedSerializedBytes.addAndGet(getEnrichmentAttrSize(event));
     }

--- a/src/test/SystemTest/docker/kafka-connect/Dockerfile
+++ b/src/test/SystemTest/docker/kafka-connect/Dockerfile
@@ -1,4 +1,5 @@
 # Create Kafka Connect image with Scalyr Sink Connector
-FROM confluentinc/cp-kafka-connect-base:latest
+#FROM confluentinc/cp-kafka-connect-base:latest # latest build doesn't even start correctly without our connector
+FROM confluentinc/cp-kafka-connect:5.5.1-1-ubi8
 RUN mkdir -p /etc/kafka-connect/jars/kafka-connect-scalyr-sink
 COPY target/kafka-connect-scalyr-sink-0.1-package/share/java/kafka-connect-scalyr-sink/ /etc/kafka-connect/jars/kafka-connect-scalyr-sink

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -78,7 +78,7 @@ public class AddEventsClientTest {
   private static final String ID = "id";
   private static final String MESSAGE = "message";
   private static final String PARSER = "parser";
-  private static final String SERVERHOST = "source";
+  private static final String SERVERHOST = "serverHost";
   private static final String LOGFILE = "logfile";
 
   private static final int numServers = 5;


### PR DESCRIPTION
Kafka is currently sending `serverHost` as  a field named `source`.   On the server side, `source` is used to create a virtual session.  Scalyr has two different terms for the same thing `source` and `serverHost`.  There are other parts of Scalyr that rely on the field being `serverHost`.

Change: Send `serverHost` both as a `serverHost` and `source` `logs` attribute.  On the server side, `source` is used for virtual session creation, `serverHost` event attribute will be promoted to a session attribute.
