### PR TITLE
CT-195 Send serverHost as __origServerHost

### DIFF
--- a/.circleci/verify_scalyr_events.py
+++ b/.circleci/verify_scalyr_events.py
@@ -146,14 +146,14 @@ def check_event_attrs(attrs):
 # {"sess_d5952fdd-eed2-45f1-8106-b2f2af55dabd": { "serverHost": "some.host.name", "parser":"accesslog"} }
 def check_session_attrs(sessions):
     DEFAULT_SOURCE = "Kafka-logs"
-    expected_attrs = ['parser', 'source']
+    expected_attrs = ['parser', 'serverHost']
     for session_attrs in sessions.values():
         is_valid_session_attrs = all (k in session_attrs for k in expected_attrs)
         if not is_valid_session_attrs:
             print("Did not get expected attributes {0}.  Query returned attributes {1}".format(expected_attrs, session_attrs))
             break
-        if session_attrs['source'] == DEFAULT_SOURCE:
-            print("source should not be default value {0}.  Check event mappings".format(DEFAULT_SOURCE))
+        if session_attrs['serverHost'] == DEFAULT_SOURCE:
+            print("serverHost should not be default value {0}.  Check event mappings".format(DEFAULT_SOURCE))
             is_valid_session_attrs = False
 
     return is_valid_session_attrs

--- a/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
+++ b/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
@@ -456,7 +456,7 @@ public class AddEventsClient implements AutoCloseable {
       jsonGenerator.writeObjectFieldStart("attrs");
 
       // __origServerHost is a stream identifier that is used to create a virtual session
-      // __origServerHost event attr will be promoted to serverHost session attr
+      // __origServerHost event attr will be promoted to serverHost session attr on the server
       if (event.getServerHost() != null) {
         jsonGenerator.writeStringField("__origServerHost", event.getServerHost());
       }

--- a/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
+++ b/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
@@ -455,12 +455,10 @@ public class AddEventsClient implements AutoCloseable {
       jsonGenerator.writeStringField("id", logId.toString());
       jsonGenerator.writeObjectFieldStart("attrs");
 
+      // __origServerHost is a stream identifier that is used to create a virtual session
+      // __origServerHost event attr will be promoted to serverHost session attr
       if (event.getServerHost() != null) {
-        jsonGenerator.writeStringField("serverHost", event.getServerHost());
-      }
-      // virtual session splitting uses source for the serverHost
-      if (event.getServerHost() != null) {
-        jsonGenerator.writeStringField("source", event.getServerHost());
+        jsonGenerator.writeStringField("__origServerHost", event.getServerHost());
       }
       if (event.getLogfile() != null) {
         jsonGenerator.writeStringField("logfile", event.getLogfile());

--- a/src/main/java/com/scalyr/integrations/kafka/EventBuffer.java
+++ b/src/main/java/com/scalyr/integrations/kafka/EventBuffer.java
@@ -21,8 +21,8 @@ public class EventBuffer {
   // Enrichment attrs are the same for all events, so we cache this
   private int cachedEnrichmentAttrSize = 0;
 
-  // Estimated per server attribute entry overhead: {"id":"999","attrs":{"serverHost":"","source":"","logfile":"","parser":""}
-  private static final int SERVER_ATTR_SERIALIZATION_OVERHEAD_BYTES = 75;
+  // Estimated per server attribute entry overhead: {"id":"999","attrs":{"__origServerHost":"","logfile":"","parser":""}
+  private static final int SERVER_ATTR_SERIALIZATION_OVERHEAD_BYTES = 70;
 
   public void addEvent(Event event) {
     eventBuffer.add(event);
@@ -68,7 +68,6 @@ public class EventBuffer {
       updateServerAttrSize(event.getLogfile());
       updateServerAttrSize(event.getParser());
       updateServerAttrSize(event.getServerHost());  // serverHost as serverHost
-      updateServerAttrSize(event.getServerHost());  // serverHost as source
       estimatedSerializedBytes.addAndGet(SERVER_ATTR_SERIALIZATION_OVERHEAD_BYTES);
       estimatedSerializedBytes.addAndGet(getEnrichmentAttrSize(event));
     }

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -78,7 +78,7 @@ public class AddEventsClientTest {
   private static final String ID = "id";
   private static final String MESSAGE = "message";
   private static final String PARSER = "parser";
-  private static final String SERVERHOST = "serverHost";
+  private static final String SERVERHOST = "__origServerHost";
   private static final String LOGFILE = "logfile";
 
   private static final int numServers = 5;

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -78,7 +78,7 @@ public class AddEventsClientTest {
   private static final String ID = "id";
   private static final String MESSAGE = "message";
   private static final String PARSER = "parser";
-  private static final String SERVERHOST = "__origServerHost";
+  private static final String ORIG_SERVERHOST = "__origServerHost";
   private static final String LOGFILE = "logfile";
 
   private static final int numServers = 5;
@@ -595,7 +595,7 @@ public class AddEventsClientTest {
 
     // Verify log level attrs
     Map logLevelAttrs = (Map) logIdAttrs.get(logId);
-    assertEquals(origEvent.getServerHost(), logLevelAttrs.get(SERVERHOST));
+    assertEquals(origEvent.getServerHost(), logLevelAttrs.get(ORIG_SERVERHOST));
     assertEquals(origEvent.getLogfile(), logLevelAttrs.get(LOGFILE));
     assertEquals(origEvent.getParser(), logLevelAttrs.get(PARSER));
     if (origEvent.getEnrichmentAttrs() != null) {


### PR DESCRIPTION
To match the server changes for CT-195:
1. Send `serverHost` as `__origServerHost` `logs` add events attribute.
2. Remove sending `serverHost` as `origin`.

This should not be merged until after CT-195 server changes are merged.