### PR TITLE
Fix `Kafka-connect/Dockerfile` to work with different version numbers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ jobs: # a collection of steps
           name: System Test
           command: |
             set -x
+            VERSION=<< pipeline.parameters.scalyr_sink_version >>
             docker-compose up -d
             docker-compose ps
 
@@ -97,10 +98,7 @@ workflows:
   version: 2
   build-and-deploy:
     jobs:
-      - build:
-          filters:
-            tags:
-              only: /.*/
+      - build
 
       - publish-github-release:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,6 @@ jobs: # a collection of steps
           name: System Test
           command: |
             set -x
-            VERSION=<< pipeline.parameters.scalyr_sink_version >>
             docker-compose up -d
             docker-compose ps
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ which is a Kafka Connect Sink Connector that allows streaming log messages from 
 ```
 mvn clean package
 ```
-Kafka Connect Scalyr will be packaged as a zip file in `target/components/packages/scalyr-kafka-connect-scalyr-sink-0.1.zip`.
+Kafka Connect Scalyr will be packaged as a zip file in `target/components/packages/scalyr-kafka-connect-scalyr-sink-<version>.zip`.
 
 ## Installation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,14 +8,14 @@
 version: '3'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:latest
+    image: confluentinc/cp-zookeeper:5.4.3
     container_name: zookeeper
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
 
   kafka:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:5.4.3
     container_name: kafka
     depends_on:
       - zookeeper
@@ -30,7 +30,7 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
   kafka-setup:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:5.4.3
     depends_on:
       - kafka
     command: "bash -c 'echo Waiting for Kafka to be ready... && \

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,30 @@
                 </executions>
             </plugin>
             <plugin>
+                <!-- Creates a symlink from kafka-connect-scalyr-sink-<version>-package to kafka-connect-scalyr-sink-latest-package
+                    since Dockerfile relies on a fixed name. -->
+                <artifactId>exec-maven-plugin</artifactId>
+                <groupId>org.codehaus.mojo</groupId>
+                <version>1.6.0</version>
+                <executions>
+                    <execution>
+                        <id>Latest Package Symlink</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>ln</executable>
+                            <arguments>
+                                <argument>-fnsv</argument>
+                                <argument>${project.artifactId}-${project.version}-package</argument>
+                                <argument>target/${project.artifactId}-latest-package</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>3.0.0</version>

--- a/src/test/SystemTest/docker/kafka-connect/Dockerfile
+++ b/src/test/SystemTest/docker/kafka-connect/Dockerfile
@@ -2,4 +2,4 @@
 #FROM confluentinc/cp-kafka-connect-base:latest # latest build doesn't even start correctly without our connector
 FROM confluentinc/cp-kafka-connect:5.5.1-1-ubi8
 RUN mkdir -p /etc/kafka-connect/jars/kafka-connect-scalyr-sink
-COPY target/kafka-connect-scalyr-sink-*-package/share/java/kafka-connect-scalyr-sink /etc/kafka-connect/jars/kafka-connect-scalyr-sink
+COPY target/kafka-connect-scalyr-sink-latest-package/share/java/kafka-connect-scalyr-sink /etc/kafka-connect/jars/kafka-connect-scalyr-sink

--- a/src/test/SystemTest/docker/kafka-connect/Dockerfile
+++ b/src/test/SystemTest/docker/kafka-connect/Dockerfile
@@ -2,4 +2,4 @@
 #FROM confluentinc/cp-kafka-connect-base:latest # latest build doesn't even start correctly without our connector
 FROM confluentinc/cp-kafka-connect:5.5.1-1-ubi8
 RUN mkdir -p /etc/kafka-connect/jars/kafka-connect-scalyr-sink
-COPY target/kafka-connect-scalyr-sink-0.1-package/share/java/kafka-connect-scalyr-sink/ /etc/kafka-connect/jars/kafka-connect-scalyr-sink
+COPY target/kafka-connect-scalyr-sink-*-package/share/java/kafka-connect-scalyr-sink /etc/kafka-connect/jars/kafka-connect-scalyr-sink


### PR DESCRIPTION
1. Fix `kafka-connect/Dockerfile` to work with different version numbers by creating a symbolic link from `kafka-connect-scalyr-sink-<Version>-package` to `kafka-connect-scalyr-sink-latest-package`.
2. Pinned Kafka Docker version to `5.4.3`.  Version 6.0 was having issues starting starting Zookeeper.

