### PR TITLE
Add filter for workflow build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,10 @@ workflows:
   version: 2
   build-and-deploy:
     jobs:
-      - build
+      - build:
+          filters:
+            tags:
+              only: /.*/
 
       - publish-github-release:
           requires:


### PR DESCRIPTION
Workflow isn't getting kicked off correctly when pushing a tag.  Make circle ci config.yml consistent with Grafana repo, which is working: https://github.com/scalyr/scalyr-grafana-datasource-plugin/blob/master/.circleci/config.yml
