### PR TITLE
Send entire SinkRecord value serialized as json in Scalyr event message field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-json</artifactId>
+            <version>${kafka.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.scalyr</groupId>
             <artifactId>scalyr-client</artifactId>
             <version>6.0.19</version>

--- a/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkConnectorConfig.java
+++ b/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkConnectorConfig.java
@@ -69,7 +69,7 @@ public class ScalyrSinkConnectorConfig extends AbstractConfig {
     + "[{\"matcher\": { \"attribute\": \"app.name\", \"value\": \"customApp\"},\n" +
     " \"eventMapping\": { \"message\": \"message\", \"logfile\": \"log.path\", \"serverHost\": \"host.hostname\", \"parser\": \"fields.parser\", \"version\": \"app.version\"} }]";
   public static final String SEND_ENTIRE_RECORD = "send_entire_record";
-  private static final String SEND_ENTIRE_RECORD_DOC = "If true, send the entire Kafka Connect record value serialized to JSON in the message field.";
+  private static final String SEND_ENTIRE_RECORD_DOC = "If true, send the entire Kafka Connect record value serialized to JSON as the message field.";
 
   public ScalyrSinkConnectorConfig(Map<String, String> parsedConfig) {
     super(configDef(), parsedConfig);

--- a/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkConnectorConfig.java
+++ b/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkConnectorConfig.java
@@ -68,6 +68,8 @@ public class ScalyrSinkConnectorConfig extends AbstractConfig {
     "  Multiple custom application event mappings can be specified in a JSON list.  Example config JSON:\n"
     + "[{\"matcher\": { \"attribute\": \"app.name\", \"value\": \"customApp\"},\n" +
     " \"eventMapping\": { \"message\": \"message\", \"logfile\": \"log.path\", \"serverHost\": \"host.hostname\", \"parser\": \"fields.parser\", \"version\": \"app.version\"} }]";
+  public static final String SEND_ENTIRE_RECORD = "send_entire_record";
+  private static final String SEND_ENTIRE_RECORD_DOC = "If true, send the entire Kafka Connect record value serialized to JSON in the message field.";
 
   public ScalyrSinkConnectorConfig(Map<String, String> parsedConfig) {
     super(configDef(), parsedConfig);
@@ -85,7 +87,8 @@ public class ScalyrSinkConnectorConfig extends AbstractConfig {
         .define(ADD_EVENTS_RETRY_DELAY_MS_CONFIG, Type.INT, DEFAULT_ADD_EVENTS_RETRY_DELAY_MS, ConfigDef.Range.atLeast(100), Importance.LOW, ADD_EVENTS_RETRY_DELAY_MS_DOC)
         .define(BATCH_SEND_SIZE_BYTES_CONFIG, Type.INT, DEFAULT_BATCH_SEND_SIZE_BYTES, ConfigDef.Range.between(500_000, 5_500_000), Importance.LOW, BATCH_SEND_SIZE_BYTES_DOC)
         .define(BATCH_SEND_WAIT_MS_CONFIG, Type.INT, DEFAULT_BATCH_SEND_WAIT_MS, ConfigDef.Range.atLeast(1000), Importance.LOW, BATCH_SEND_WAIT_MS_DOC)
-        .define(CUSTOM_APP_EVENT_MAPPING_CONFIG, Type.STRING, null, customAppEventMappingValidator, Importance.MEDIUM, CUSTOM_APP_EVENT_MAPPING_DOC);
+        .define(CUSTOM_APP_EVENT_MAPPING_CONFIG, Type.STRING, null, customAppEventMappingValidator, Importance.MEDIUM, CUSTOM_APP_EVENT_MAPPING_DOC)
+        .define(SEND_ENTIRE_RECORD, Type.BOOLEAN, false, Importance.LOW, SEND_ENTIRE_RECORD_DOC);
   }
 
 

--- a/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkTask.java
+++ b/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkTask.java
@@ -115,7 +115,8 @@ public class ScalyrSinkTask extends SinkTask {
 
     this.eventMapper = new EventMapper(
       parseEnrichmentAttrs(sinkConfig.getList(ScalyrSinkConnectorConfig.EVENT_ENRICHMENT_CONFIG)),
-      parseCustomAppEventMapping(sinkConfig.getString(ScalyrSinkConnectorConfig.CUSTOM_APP_EVENT_MAPPING_CONFIG)));
+      parseCustomAppEventMapping(sinkConfig.getString(ScalyrSinkConnectorConfig.CUSTOM_APP_EVENT_MAPPING_CONFIG)),
+      sinkConfig.getBoolean(ScalyrSinkConnectorConfig.SEND_ENTIRE_RECORD));
 
     log.info("Started ScalyrSinkTask with config {}", configProps);
   }

--- a/src/main/java/com/scalyr/integrations/kafka/mapping/JsonRecordToMessageMapping.java
+++ b/src/main/java/com/scalyr/integrations/kafka/mapping/JsonRecordToMessageMapping.java
@@ -30,13 +30,14 @@ import java.util.Map;
  * The typical use case for this is when the Kafka record value is JSON and the entire JSON needs to be sent to Scalyr.
  */
 public class JsonRecordToMessageMapping implements MessageMapper {
+  /** MessageMapper for the SinkRecord message format. */
   private final MessageMapper baseMapper;
-  private final JsonConverter converter;
+  private final JsonConverter jsonConverter;
 
   public JsonRecordToMessageMapping(MessageMapper baseMapper) {
     this.baseMapper = baseMapper;
-    converter = new JsonConverter();
-    converter.configure(ImmutableMap.of(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, false, ConverterConfig.TYPE_CONFIG, "value"));
+    jsonConverter = new JsonConverter();
+    jsonConverter.configure(ImmutableMap.of(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, false, ConverterConfig.TYPE_CONFIG, "value"));
   }
 
   @Override
@@ -56,7 +57,7 @@ public class JsonRecordToMessageMapping implements MessageMapper {
 
   @Override
   public String getMessage(SinkRecord record) {
-    return new String(converter.fromConnectData(
+    return new String(jsonConverter.fromConnectData(
       record.topic(),
       record.valueSchema(),
       record.value()),

--- a/src/main/java/com/scalyr/integrations/kafka/mapping/JsonRecordToMessageMapping.java
+++ b/src/main/java/com/scalyr/integrations/kafka/mapping/JsonRecordToMessageMapping.java
@@ -1,0 +1,60 @@
+package com.scalyr.integrations.kafka.mapping;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.json.JsonConverterConfig;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.storage.ConverterConfig;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * Decorator for base MessageMapper which will map the entire Record value to the message field.
+ * This is used to send the entire Kafka record value serialized as JSON to Scalyr in the Scalyr event `message` field.
+ * The typical use case for this is when the Kafka record value is JSON and the entire JSON needs to be sent to Scalyr.
+ */
+public class JsonRecordToMessageMapping implements MessageMapper {
+  private final MessageMapper baseMapper;
+  private final JsonConverter converter;
+
+  public JsonRecordToMessageMapping(MessageMapper baseMapper) {
+    this.baseMapper = baseMapper;
+    converter = new JsonConverter();
+    converter.configure(ImmutableMap.of(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, false, ConverterConfig.TYPE_CONFIG, "value"));
+  }
+
+  @Override
+  public String getServerHost(SinkRecord record) {
+    return baseMapper.getServerHost(record);
+  }
+
+  @Override
+  public String getLogfile(SinkRecord record) {
+    return baseMapper.getLogfile(record);
+  }
+
+  @Override
+  public String getParser(SinkRecord record) {
+    return baseMapper.getParser(record);
+  }
+
+  @Override
+  public String getMessage(SinkRecord record) {
+    return new String(converter.fromConnectData(
+      record.topic(),
+      record.valueSchema(),
+      record.value()),
+      StandardCharsets.UTF_8);
+  }
+
+  @Override
+  public Map<String, Object> getAdditionalAttrs(SinkRecord record) {
+    return baseMapper.getAdditionalAttrs(record);
+  }
+
+  @Override
+  public boolean matches(SinkRecord record) {
+    return baseMapper.matches(record);
+  }
+}

--- a/src/main/java/com/scalyr/integrations/kafka/mapping/JsonRecordToMessageMapping.java
+++ b/src/main/java/com/scalyr/integrations/kafka/mapping/JsonRecordToMessageMapping.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Scalyr Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.scalyr.integrations.kafka.mapping;
 
 import com.google.common.collect.ImmutableMap;

--- a/src/test/java/com/scalyr/integrations/kafka/ScalyrSinkConnectorConfigTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/ScalyrSinkConnectorConfigTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import static com.scalyr.integrations.kafka.ScalyrSinkConnectorConfig.*;
 import static com.scalyr.integrations.kafka.TestUtils.fails;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -64,7 +65,8 @@ public class ScalyrSinkConnectorConfigTest {
       EVENT_ENRICHMENT_CONFIG, TEST_EVENT_ENRICHMENT,
       BATCH_SEND_SIZE_BYTES_CONFIG, TEST_BATCH_SEND_SIZE,
       BATCH_SEND_WAIT_MS_CONFIG, TEST_BATCH_SEND_WAIT_MS,
-      CUSTOM_APP_EVENT_MAPPING_CONFIG, TestValues.CUSTOM_APP_EVENT_MAPPING_JSON);
+      CUSTOM_APP_EVENT_MAPPING_CONFIG, TestValues.CUSTOM_APP_EVENT_MAPPING_JSON,
+      SEND_ENTIRE_RECORD, "true");
 
     ScalyrSinkConnectorConfig connectorConfig = new ScalyrSinkConnectorConfig(config);
     assertEquals(TEST_SCALYR_SERVER, connectorConfig.getString(SCALYR_SERVER_CONFIG));
@@ -77,6 +79,7 @@ public class ScalyrSinkConnectorConfigTest {
     assertEquals(Integer.valueOf(TEST_BATCH_SEND_SIZE), connectorConfig.getInt(BATCH_SEND_SIZE_BYTES_CONFIG));
     assertEquals(Integer.valueOf(TEST_BATCH_SEND_WAIT_MS), connectorConfig.getInt(BATCH_SEND_WAIT_MS_CONFIG));
     assertEquals(TestValues.CUSTOM_APP_EVENT_MAPPING_JSON, connectorConfig.getString(CUSTOM_APP_EVENT_MAPPING_CONFIG));
+    assertTrue(connectorConfig.getBoolean(SEND_ENTIRE_RECORD));
   }
 
   /**
@@ -97,6 +100,7 @@ public class ScalyrSinkConnectorConfigTest {
     assertEquals(DEFAULT_BATCH_SEND_SIZE_BYTES, connectorConfig.getInt(BATCH_SEND_SIZE_BYTES_CONFIG).intValue());
     assertEquals(DEFAULT_BATCH_SEND_WAIT_MS, connectorConfig.getInt(BATCH_SEND_WAIT_MS_CONFIG).intValue());
     assertNull(connectorConfig.getString(CUSTOM_APP_EVENT_MAPPING_CONFIG));
+    assertFalse(connectorConfig.getBoolean(SEND_ENTIRE_RECORD));
   }
 
   /**
@@ -175,6 +179,10 @@ public class ScalyrSinkConnectorConfigTest {
     config.put(ADD_EVENTS_RETRY_DELAY_MS_CONFIG, "1");
     fails(() -> new ScalyrSinkConnectorConfig(config), ConfigException.class);
     config.remove(ADD_EVENTS_RETRY_DELAY_MS_CONFIG);
+
+    config.put(SEND_ENTIRE_RECORD, "invalidBoolean");
+    fails(() -> new ScalyrSinkConnectorConfig(config), ConfigException.class);
+    config.remove(SEND_ENTIRE_RECORD);
   }
 
   /**
@@ -254,7 +262,7 @@ public class ScalyrSinkConnectorConfigTest {
     final ImmutableSet<String> configs = ImmutableSet.of(SCALYR_SERVER_CONFIG, SCALYR_API_CONFIG,
       COMPRESSION_TYPE_CONFIG, COMPRESSION_LEVEL_CONFIG, ADD_EVENTS_TIMEOUT_MS_CONFIG,
       ADD_EVENTS_RETRY_DELAY_MS_CONFIG, EVENT_ENRICHMENT_CONFIG,
-      BATCH_SEND_SIZE_BYTES_CONFIG, BATCH_SEND_WAIT_MS_CONFIG, CUSTOM_APP_EVENT_MAPPING_CONFIG);
+      BATCH_SEND_SIZE_BYTES_CONFIG, BATCH_SEND_WAIT_MS_CONFIG, CUSTOM_APP_EVENT_MAPPING_CONFIG, SEND_ENTIRE_RECORD);
 
     ConfigDef configDef = ScalyrSinkConnectorConfig.configDef();
     assertEquals(configs.size(), configDef.names().size());

--- a/src/test/java/com/scalyr/integrations/kafka/ScalyrSinkConnectorTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/ScalyrSinkConnectorTest.java
@@ -79,7 +79,7 @@ public class ScalyrSinkConnectorTest {
     scalyrSinkConnector.start(config);
     List<Map<String, String>> taskConfigs = scalyrSinkConnector.taskConfigs(numTaskConfigs);
     assertEquals(numTaskConfigs, taskConfigs.size());
-    taskConfigs.forEach(taskConfig -> TestUtils.verifyMap(config, taskConfig));
+    taskConfigs.forEach(taskConfig -> assertEquals(config, taskConfig));
   }
 
   /**

--- a/src/test/java/com/scalyr/integrations/kafka/mapping/CustomAppMessageMapperTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/mapping/CustomAppMessageMapperTest.java
@@ -16,6 +16,7 @@
 
 package com.scalyr.integrations.kafka.mapping;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.scalyr.integrations.kafka.TestUtils;
 import com.scalyr.integrations.kafka.TestValues;
 import org.apache.kafka.connect.data.Schema;
@@ -60,7 +61,7 @@ public class CustomAppMessageMapperTest {
    * Typically this is parsed from JSON, but we construct it programmatically here.
    * See {@link CustomAppRecordValueCreator} for the app fields.
    */
-  private CustomAppEventMapping createCustomAppEventMapping() {
+  @VisibleForTesting static CustomAppEventMapping createCustomAppEventMapping() {
     CustomAppEventMapping customAppEventMapping = new CustomAppEventMapping();
     customAppEventMapping.setEventMapping(TestUtils.makeMap(
       "id", "id",

--- a/src/test/java/com/scalyr/integrations/kafka/mapping/JsonRecordToMessageMappingTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/mapping/JsonRecordToMessageMappingTest.java
@@ -1,0 +1,84 @@
+package com.scalyr.integrations.kafka.mapping;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.scalyr.integrations.kafka.TestValues;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Test for JsonRecordToMessageMapping
+ */
+public class JsonRecordToMessageMappingTest {
+  private static final AtomicInteger offset = new AtomicInteger();
+  private ObjectMapper objectMapper = new ObjectMapper();
+  private MessageMapper messageMapper;
+  private SinkRecordValueCreator sinkRecordValueCreator;
+
+  private static final String topic = "test-topic";
+  private static final int partition = 0;
+
+  @Before
+  public void setup() {
+    final CustomAppMessageMapper customAppMessageMapper = new CustomAppMessageMapper(CustomAppMessageMapperTest.createCustomAppEventMapping());
+    messageMapper = new JsonRecordToMessageMapping(customAppMessageMapper);
+    sinkRecordValueCreator = new CustomAppMessageMapperTest.CustomAppRecordValueCreator();
+  }
+
+  /**
+   * Test mapper gets correct values for schemaless record value
+   */
+  @Test
+  public void testCustomAppMessageMapperSchemaless() throws Exception {
+    SinkRecord record = new SinkRecord(topic, partition, null, null, null, sinkRecordValueCreator.createSchemalessRecordValue(1, 1, 1), offset.getAndIncrement());
+    verifySinkRecord(record);
+  }
+
+  /**
+   * Test mapper gets correct values for schema record value
+   */
+  @Test
+  public void testCustomAppMessageMapperSchema() throws Exception {
+    final Struct schemaRecordValue = sinkRecordValueCreator.createSchemaRecordValue(1, 1, 1);
+    SinkRecord record = new SinkRecord(topic, partition, null, null, schemaRecordValue.schema(), schemaRecordValue, offset.getAndIncrement());
+    verifySinkRecord(record);
+  }
+
+  private void verifySinkRecord(SinkRecord record) throws Exception {
+    assertEquals(TestValues.CUSTOM_APP_NAME, messageMapper.getLogfile(record));
+    assertEquals(TestValues.PARSER_VALUE, messageMapper.getParser(record));
+    assertEquals(TestValues.SERVER_VALUE + "0", messageMapper.getServerHost(record));
+    Map<String, Object> additionalAttrs = messageMapper.getAdditionalAttrs(record);
+    assertNotNull(additionalAttrs.get("id"));
+    assertEquals(TestValues.SEVERITY_VALUE, additionalAttrs.get("severity"));
+    assertEquals(TestValues.CUSTOM_APP_VERSION, additionalAttrs.get("version"));
+    assertEquals(TestValues.CUSTOM_APP_NAME, additionalAttrs.get("application"));
+    assertEquals(TestValues.ACTIVITY_TYPE_VALUE, additionalAttrs.get("activityType"));
+
+    // Verify message field, which should contain the entire record value serialized to JSON
+    if (record.value() instanceof Map) {
+      // Schemaless record value
+      assertEquals(objectMapper.writeValueAsString(record.value()), messageMapper.getMessage(record));
+    } else if (record.value() instanceof Struct){
+      // Schema record value
+      // Can't easily serialize a Struct to JSON without calling the same code that did the serialization.
+      // To verify, we check that the message field contains valid JSON by parsing the serialized JSON in the Event message
+      // and verify that the parsed JSON contains the original message field.
+      final Map<String, Object> messageJson = objectMapper.readValue(messageMapper.getMessage(record), Map.class);
+      assertEquals(TestValues.MESSAGE_VALUE, messageJson.get("message"));
+    } else {
+      fail("Invalid record value");
+    }
+
+    assertTrue(messageMapper.matches(record));
+  }
+}

--- a/src/test/java/com/scalyr/integrations/kafka/mapping/JsonRecordToMessageMappingTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/mapping/JsonRecordToMessageMappingTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Scalyr Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.scalyr.integrations.kafka.mapping;
 
 import com.scalyr.integrations.kafka.TestUtils;

--- a/src/test/java/com/scalyr/integrations/kafka/mapping/JsonRecordToMessageMappingTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/mapping/JsonRecordToMessageMappingTest.java
@@ -1,6 +1,6 @@
 package com.scalyr.integrations.kafka.mapping;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.scalyr.integrations.kafka.TestUtils;
 import com.scalyr.integrations.kafka.TestValues;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -20,7 +20,6 @@ import static org.junit.Assert.fail;
  */
 public class JsonRecordToMessageMappingTest {
   private static final AtomicInteger offset = new AtomicInteger();
-  private ObjectMapper objectMapper = new ObjectMapper();
   private MessageMapper messageMapper;
   private SinkRecordValueCreator sinkRecordValueCreator;
 
@@ -67,14 +66,10 @@ public class JsonRecordToMessageMappingTest {
     // Verify message field, which should contain the entire record value serialized to JSON
     if (record.value() instanceof Map) {
       // Schemaless record value
-      assertEquals(objectMapper.writeValueAsString(record.value()), messageMapper.getMessage(record));
+      TestUtils.verifyMap((Map)record.value(), messageMapper.getMessage(record));
     } else if (record.value() instanceof Struct){
       // Schema record value
-      // Can't easily serialize a Struct to JSON without calling the same code that did the serialization.
-      // To verify, we check that the message field contains valid JSON by parsing the serialized JSON in the Event message
-      // and verify that the parsed JSON contains the original message field.
-      final Map<String, Object> messageJson = objectMapper.readValue(messageMapper.getMessage(record), Map.class);
-      assertEquals(TestValues.MESSAGE_VALUE, messageJson.get("message"));
+      TestUtils.verifyStruct((Struct)record.value(), messageMapper.getMessage(record));
     } else {
       fail("Invalid record value");
     }

--- a/src/test/java/com/scalyr/integrations/kafka/mapping/JsonRecordToMessageMappingTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/mapping/JsonRecordToMessageMappingTest.java
@@ -34,7 +34,8 @@ import static org.junit.Assert.fail;
  * Test for JsonRecordToMessageMapping
  */
 public class JsonRecordToMessageMappingTest {
-  private static final AtomicInteger offset = new AtomicInteger();
+  /** Simulated Kafka partition offset */
+  private static final AtomicInteger kafkaOffset = new AtomicInteger();
   private MessageMapper messageMapper;
   private SinkRecordValueCreator sinkRecordValueCreator;
 
@@ -53,7 +54,7 @@ public class JsonRecordToMessageMappingTest {
    */
   @Test
   public void testCustomAppMessageMapperSchemaless() throws Exception {
-    SinkRecord record = new SinkRecord(topic, partition, null, null, null, sinkRecordValueCreator.createSchemalessRecordValue(1, 1, 1), offset.getAndIncrement());
+    SinkRecord record = new SinkRecord(topic, partition, null, null, null, sinkRecordValueCreator.createSchemalessRecordValue(1, 1, 1), kafkaOffset.getAndIncrement());
     verifySinkRecord(record);
   }
 
@@ -63,7 +64,7 @@ public class JsonRecordToMessageMappingTest {
   @Test
   public void testCustomAppMessageMapperSchema() throws Exception {
     final Struct schemaRecordValue = sinkRecordValueCreator.createSchemaRecordValue(1, 1, 1);
-    SinkRecord record = new SinkRecord(topic, partition, null, null, schemaRecordValue.schema(), schemaRecordValue, offset.getAndIncrement());
+    SinkRecord record = new SinkRecord(topic, partition, null, null, schemaRecordValue.schema(), schemaRecordValue, kafkaOffset.getAndIncrement());
     verifySinkRecord(record);
   }
 


### PR DESCRIPTION
# Overview
In order to support sending the entire JSON record in a Kafka message without creating a custom event mapping for each field, a new config `send_entire_record` parameter is added.  If `send_entire_record` is `true`, it will serialize the `SinkRecord` value to JSON and send it in the Scalyr event `message` field.

# Changes
1. Added `JsonRecordToMessageMapping` which uses the Decorator pattern and returns the serialized `SinkRecord` value for `getMessage`.
2. Introduced a new `send_entire_record` config parameter to enable this feature.
3. Test params are modified to run tests with `send_entire_record` set to both `true` and `false`.
4. Since serializing the entire record value to JSON affects the message and event size, some `ScalyrSinkTask` tests that test the batch size which are sensitive to the message size are only conditionally when `send_entire_record=false`.

May be easier to review by commit.

# Test Result
Sample integration test result: https://app.scalyr.com/y/czrybHtVGxG

One thing to note is that `send_entire_record` sends the entire record for all data sources including Filebeats.  I viewed that as a feature to easily send all Filebeats fields to Scalyr, although that may be debatable.  We could exclude Filebeats from this.