### PR TITLE
CT-163 Optimize Event.estimatedSerializedBytes

### DIFF
--- a/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
+++ b/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
@@ -519,9 +519,11 @@ public class AddEventsClient implements AutoCloseable {
      */
     private void writeEventAttrs(Event event, JsonGenerator jsonGenerator) throws IOException {
       jsonGenerator.writeObjectFieldStart("attrs");
-      jsonGenerator.writeFieldName("message");
-      byte[] quotedMsg = event.getSerializedMessage().asQuotedUTF8();
-      jsonGenerator.writeRawUTF8String(quotedMsg, 0, quotedMsg.length);
+      if (event.getSerializedMessage() != null) {
+        jsonGenerator.writeFieldName("message");
+        byte[] quotedMsg = event.getSerializedMessage().asQuotedUTF8();
+        jsonGenerator.writeRawUTF8String(quotedMsg, 0, quotedMsg.length);
+      }
 
       // Write additional attrs
       if (event.getAdditionalAttrs() != null) {

--- a/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
+++ b/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
@@ -519,7 +519,9 @@ public class AddEventsClient implements AutoCloseable {
      */
     private void writeEventAttrs(Event event, JsonGenerator jsonGenerator) throws IOException {
       jsonGenerator.writeObjectFieldStart("attrs");
-      jsonGenerator.writeStringField("message", event.getMessage());
+      jsonGenerator.writeFieldName("message");
+      byte[] quotedMsg = event.getSerializedMessage().asQuotedUTF8();
+      jsonGenerator.writeRawUTF8String(quotedMsg, 0, quotedMsg.length);
 
       // Write additional attrs
       if (event.getAdditionalAttrs() != null) {

--- a/src/main/java/com/scalyr/integrations/kafka/Event.java
+++ b/src/main/java/com/scalyr/integrations/kafka/Event.java
@@ -16,6 +16,7 @@
 
 package com.scalyr.integrations.kafka;
 
+import com.fasterxml.jackson.core.io.SerializedString;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 
@@ -47,7 +48,7 @@ public class Event {
 
   // Event level fields
   private long timestamp;
-  private String message;
+  private SerializedString message;
   private Map<String, Object> additionalAttrs;
 
   // Cached estimated event size
@@ -106,7 +107,7 @@ public class Event {
   }
 
   public Event setMessage(String message) {
-    this.message = message;
+    this.message = message == null ? null : new SerializedString(message);
     return this;
   }
 
@@ -169,7 +170,9 @@ public class Event {
     return timestamp;
   }
 
-  public String getMessage() {
+  public String getMessage() { return message == null ? null : message.getValue(); }
+
+  public SerializedString getSerializedMessage() {
     return message;
   }
 
@@ -186,7 +189,7 @@ public class Event {
       return estimatedSizeBytes;
     }
 
-    int size = Strings.isNullOrEmpty(getMessage()) ? 0 : estimateEscapedStringSize(getMessage());
+    int size = Strings.isNullOrEmpty(getMessage()) ? 0 : getSerializedMessage().asQuotedUTF8().length;
     size += getTopic().length();
     size += EVENT_SERIALIZATION_OVERHEAD_BYTES;
 

--- a/src/main/java/com/scalyr/integrations/kafka/Event.java
+++ b/src/main/java/com/scalyr/integrations/kafka/Event.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.IntStream;
 
 /**
  * Abstraction for a Scalyr Event.
@@ -222,11 +221,14 @@ public class Event {
     return s.length();
   }
 
-  private int countJsonEscapedCharacters(String s) {
-    return (int)IntStream.range(0, s.length())
-      .mapToObj(s::charAt)
-      .filter(JSON_ESCAPED_CHARS::contains)
-      .count();
+  public int countJsonEscapedCharacters(String s) {
+    int escapedChars = 0;
+    for (int i = 0; i < s.length(); i++) {
+      if (JSON_ESCAPED_CHARS.contains(s.charAt(i))) {
+        escapedChars++;
+      }
+    }
+    return escapedChars;
   }
 
   /**

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -122,6 +122,16 @@ public class AddEventsClientTest {
   }
 
   /**
+   * Verify JSON in Event message serialization
+   */
+  @Test
+  public void jsonMessageTest() throws IOException {
+    final String jsonMsg = "{\"k1\":\"v1\", \"k2\":\"v2\", \"k3\": 1.0, \"k4\": {\"k1\":\"v1\", \"k2\":\"v2\"}}";
+    List<Event> events = TestUtils.createTestEvents(10, jsonMsg, 1, 1, 1);
+    createAndVerifyAddEventsRequest(events);
+  }
+
+  /**
    * Create `numEvents` with the specified `numServers`, `numLogFiles`, `numParsers`
    * and verify the AddEventsRequest is serialized correctly to JSON.
    */

--- a/src/test/java/com/scalyr/integrations/kafka/EventBufferTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/EventBufferTest.java
@@ -63,6 +63,23 @@ public class EventBufferTest {
   }
 
   /**
+   * Test add events payload estimate with no message attribute.
+   */
+  @Test
+  public void testNullMessage() throws Exception {
+    final int numEvents = 1000;
+    EventBuffer eventBuffer = new EventBuffer();
+    TestUtils.createTestEvents(numEvents, null, 100, 1, 1)
+      .forEach(eventBuffer::addEvent);
+
+    final int estimatedSerializedBytes = eventBuffer.estimatedSerializedBytes();
+    final int actualSerializedBytes = actualSerializedSize(eventBuffer.getEvents());
+    // message field is not included in serialized payload when null, although estimates still include `message`
+    // allow bigger delta to account for this
+    assertEquals(actualSerializedBytes, estimatedSerializedBytes, actualSerializedBytes * deltaPercent * 2);
+  }
+
+  /**
    * Calculate add events payload serialized size.
    */
   private int actualSerializedSize(List<Event> events) throws Exception {

--- a/src/test/java/com/scalyr/integrations/kafka/TestUtils.java
+++ b/src/test/java/com/scalyr/integrations/kafka/TestUtils.java
@@ -138,6 +138,7 @@ public class TestUtils {
           .addAdditionalAttr("app", "test")
           .addAdditionalAttr("isTest", true)
           .addAdditionalAttr("version", 2.3)
+          .addAdditionalAttr("jsonAttr", "{\"k1\":\"v1\"}")
           .setEnrichmentAttrs(TestValues.ENRICHMENT_VALUE_MAP);
       });
   }


### PR DESCRIPTION
High CPU utilization was reported with the Kafka Connect Scalyr Sink.

We did CPU profiling to determine the cause.

Profiling results showed the following:
* 40% of the time was spent in non-Java code
* 30% of the time is spent polling the topic
* 5% of the time is spent executing Scalyr code in `ScalyrSinkTask`

The results may be skewed due to the system not being fully loaded and there is a lot of idle polling operations occurring.

We identified the following:
1. Running more tasks than needed results in CPU overhead from each task starting a Kafka consumer to poll the topic.
2. Within `ScalyrSinkTask.put`, 25% of the 5% in Scalyr code was spent in `Event.estimatedSerializedBytes`

Microbenchmarking showed  the following for a large 7K JSON String executed 100_000 times:
Estimate serialization size using for loop: 3362
Estimate serialization size using stream: 7843
Estimate serialization size  using Jackson SerializedString: 2962
Estimate serialization size  re-using Jackson SerializedString: 3 ms

Made the following changes:
1. Changed `Event.countJsonEscapedCharacters` to use for loop instead of String.  This method is still used for estimating `Event.additionalAttributes`
2. Changed `Event.message` to use Jackson `SerializedString`.  `SerializedString` will generate the actual serialized String and cache the value. The `SerializedString` is used to determine the serialized `message` length and the cached value is re-used when performing the actual serialization.

These changes reduced the amount of time in `Event.estimatedSerializedBytes` 1% to 0.36%.