### PR TITLE
Release Kafka Connect Scalyr Sink version 1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 parameters:
   scalyr_sink_version: # scalyr_sink_version needs to be updated on every new version release.
     type: string
-    default: "1.0"
+    default: "1.1"
 
 jobs: # a collection of steps
   build: # runs not using Workflows must have a `build` job as entry point

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,6 @@ Features:
 * Supports custom application log messages using user defined conversion of message fields to Scalyr log event attributes.
 * Supports Fluentd and Fluent Bit using custom application event mappings.
 * Exactly once delivery using the topic, partition, and offset to uniquely identify events and prevent duplicate delivery.
+
+## 1.1
+Performance improvements for JSON serialization.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,17 @@
+# Maintainers Documentation
+
+## Release checklist
+
+* Please make sure CHANGELOG reflects the new version to be released
+  (Usually, that's changing the `In Development` items to be reflected under
+   new version and leaving `In Development` empty)
+* Set the new version to be released in pom.xml and config.yml
+* Please push a tag using git commands
+
+    ```bash
+    git tag -a 1.0 -m "1.0 - Shiny new features and bug fixes"
+    git push upstream 1.0
+    ```
+
+* Circle CI builds the tag and ships to GitHub Releases
+* `scalyr-kafka-connect-scalyr-sink-<version>.zip` is included in the GitHub Releases Downloads

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.scalyr.integrations.kafka</groupId>
     <artifactId>kafka-connect-scalyr-sink</artifactId>
-    <version>1.0</version>
+    <version>1.1</version>
     <packaging>jar</packaging>
 
     <name>kafka-connect-scalyr-sink</name>


### PR DESCRIPTION
Update versions and `CHANGELOG` in preparation for 1.1 release.