### PR TITLE
Allow two digit version number for release tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,4 +110,4 @@ workflows:
               ignore: /.*/
             tags:
               # See https://discuss.circleci.com/t/filter-job-by-tag-not-working-regexp-possibly-unsupported/28484
-              only: /^(\d|[1-9]\d*)\.(\d|[1-9]\d*)\.(\d|[1-9]\d*)(-(0|[1-9A-Za-z-][0-9A-Za-z-]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9A-Za-z-][0-9A-Za-z-]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/
+              only: /^(\d|[1-9]\d*)\.(\d|[1-9]\d*)(\.(\d|[1-9]\d*))?(-(0|[1-9A-Za-z-][0-9A-Za-z-]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9A-Za-z-][0-9A-Za-z-]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,7 +10,7 @@
 
     ```bash
     git tag -a 1.0 -m "1.0 - Shiny new features and bug fixes"
-    git push upstream 1.0
+    git push origin 1.0
     ```
 
 * Circle CI builds the tag and ships to GitHub Releases


### PR DESCRIPTION
Currently, the `config.yml` will only push to Github Releases if the version tag has three digits (e.g. `1.0.0`).  Change to allow two digit tags (e.g. `1.0`) to also push to Github Releases.