### PR TITLE
Change ScalyrSinkConnectorConfig validation to allow no message/application attributes when send_entire_record=true

### DIFF
--- a/src/test/java/com/scalyr/integrations/kafka/ScalyrSinkConnectorConfigTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/ScalyrSinkConnectorConfigTest.java
@@ -218,12 +218,21 @@ public class ScalyrSinkConnectorConfigTest {
     fails(() -> new ScalyrSinkConnectorConfig(config), ConfigException.class);
     config.remove(CUSTOM_APP_EVENT_MAPPING_CONFIG);
 
-    // No event mapping
+    // No event mapping when SEND_ENTIRE_RECORD=false
     customAppEventMapping = TestValues.createCustomAppEventMapping(".");
     customAppEventMapping.remove("eventMapping");
     config.put(CUSTOM_APP_EVENT_MAPPING_CONFIG, objectMapper.writeValueAsString(Collections.singletonList(customAppEventMapping)));
     fails(() -> new ScalyrSinkConnectorConfig(config), ConfigException.class);
     config.remove(CUSTOM_APP_EVENT_MAPPING_CONFIG);
+
+    // No event mapping when SEND_ENTIRE_RECORD=true
+    customAppEventMapping = TestValues.createCustomAppEventMapping(".");
+    customAppEventMapping.remove("eventMapping");
+    config.put(CUSTOM_APP_EVENT_MAPPING_CONFIG, objectMapper.writeValueAsString(Collections.singletonList(customAppEventMapping)));
+    config.put(SEND_ENTIRE_RECORD, "true");
+    new ScalyrSinkConnectorConfig(config);
+    config.remove(CUSTOM_APP_EVENT_MAPPING_CONFIG);
+    config.remove(SEND_ENTIRE_RECORD);
 
     // Empty matcher
     customAppEventMapping = TestValues.createCustomAppEventMapping(".");


### PR DESCRIPTION
Change `ScalyrSinkConnectorConfig` to not require message/application attributes for `custom_app_event_mapping` when `send_entire_record=true`.

The Kafka Connect `ConfigDef.Validator` validates config fields independently of each other.  To support the new `send_entire_record`, we would like to allow no message/application attribute mappings when `send_entire_record=true` and enforce having message/application attribute mappings when `send_entire_record=false`.  To do this, we add a new validation method to validate `custom_app_event_mapping`  message/application attributes in the context of `send_entire_record` config param.

