### PR TITLE
CT-278 Support wildcards and matchAll for custom app event mapping

### DIFF
--- a/config/connect-scalyr-sink-custom-app.json
+++ b/config/connect-scalyr-sink-custom-app.json
@@ -8,6 +8,6 @@
     "topics": "logs",
     "api_key": "<log write api key from https://app.scalyr.com/keys>",
     "event_enrichment": "key1=value1,key2=value2",
-    "custom_app_event_mapping":"[{\"matcher\": {\"attribute\": \"app.name\", \"value\": \"myapp\"}, \"eventMapping\": {\"message\": \"message\", \"logfile\": \"log.path\", \"serverHost\": \"host.hostname\", \"parser\": \"fields.parser\", \"version\": \"app.version\", \"appField1\":\"appField1\", \"appField2\":\"nested.appField2\"}}]"
+    "custom_app_event_mapping":"[{\"matcher\": {\"attribute\": \"app.name\", \"value\": \"myApp.*\"}, \"eventMapping\": {\"message\": \"message\", \"logfile\": \"log.path\", \"serverHost\": \"host.hostname\", \"parser\": \"fields.parser\", \"version\": \"app.version\", \"appField1\":\"appField1\", \"appField2\":\"nested.appField2\"}}, {\"matcher\": {\"matchAll\": \"true\"}, \"eventMapping\": {\"message\": \"message\", \"logfile\": \"log.path\", \"serverHost\": \"host.hostname\", \"parser\": \"fields.parser\"}}]"
   }
 }

--- a/config/connect-scalyr-sink.properties
+++ b/config/connect-scalyr-sink.properties
@@ -21,7 +21,7 @@ api_key=<log write api key from https://app.scalyr.com/keys>
 
 # Custom application event mapping with match all and send_entire_record=true
 # logfile, serverHost, and parser event mappings are still recommended, since these are special fields.
-# send_entire_record=true will send all other fields.
+#send_entire_record=true
 #custom_app_event_mapping=[{"matcher": {"matchAll": true}, "eventMapping": {"logfile": "log.path", "serverHost": "host.hostname", "parser": "fields.parser"}}]
 
 # Advanced configuration options - these should not be modified in most cases

--- a/config/connect-scalyr-sink.properties
+++ b/config/connect-scalyr-sink.properties
@@ -16,8 +16,13 @@ api_key=<log write api key from https://app.scalyr.com/keys>
 # Optional enrichment attributes in key=value format which are added to the Scalyr event attributes
 #event_enrichment=key1=value1,key2=value2
 
-# Custom application event mapping - only needed for custom applications
-#custom_app_event_mapping=[{"matcher": {"attribute": "app.name", "value": "myapp"}, "eventMapping": {"message": "message", "logfile": "log.path", "serverHost": "host.hostname", "parser": "fields.parser", "version": "app.version", "appField1", "appField1", "appField2", "nested.appField2"}}]
+# Custom application event mapping - only needed for custom applications.  Regex is supported for the `matcher.value`.
+#custom_app_event_mapping=[{"matcher": {"attribute": "app.name", "value": "myapp.*"}, "eventMapping": {"message": "message", "logfile": "log.path", "serverHost": "host.hostname", "parser": "fields.parser", "version": "app.version", "appField1", "appField1", "appField2", "nested.appField2"}}]
+
+# Custom application event mapping with match all and send_entire_record=true
+# logfile, serverHost, and parser event mappings are still recommended, since these are special fields.
+# send_entire_record=true will send all other fields.
+#custom_app_event_mapping=[{"matcher": {"matchAll": true}, "eventMapping": {"logfile": "log.path", "serverHost": "host.hostname", "parser": "fields.parser"}}]
 
 # Advanced configuration options - these should not be modified in most cases
 # Compression type to use for sending log events.  Valid values are: `deflate`, `none`.

--- a/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkConnectorConfig.java
+++ b/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkConnectorConfig.java
@@ -66,7 +66,7 @@ public class ScalyrSinkConnectorConfig extends AbstractConfig {
   public static final String CUSTOM_APP_EVENT_MAPPING_CONFIG = "custom_app_event_mapping";
   private static final String CUSTOM_APP_EVENT_MAPPING_DOC = "JSON config describing how to map custom application nested Kafka messages to Scalyr events." +
     "  Multiple custom application event mappings can be specified in a JSON list and are evaluated in the order specified in the list." +
-    "  Regex is supported for the matcher.value.  Example config JSON:\n" +
+    "  The matcher.value supports regex to match the entire field value.  Example config JSON:\n" +
     "[{\"matcher\": { \"attribute\": \"app.name\", \"value\": \"mpApp.*\"},\n" +
     " \"eventMapping\": { \"message\": \"message\", \"logfile\": \"log.path\", \"serverHost\": \"host.hostname\", \"parser\": \"fields.parser\", \"version\": \"app.version\"} },\n" +
     "{\"matcher\": { \"matchAll\": true},\n" +
@@ -157,7 +157,7 @@ public class ScalyrSinkConnectorConfig extends AbstractConfig {
       }
       // Custom event mappings are evaluated in order.  Match all should be last so that other custom event mappings are evaluated.
       if (numMatchAll == 1 && !customAppEventMappings.get(customAppEventMappings.size() - 1).isMatchAll()) {
-        throw new ConfigException("Match all custom event mapping matcher should be defined last so other custom event mappings can match");
+        throw new ConfigException("Custom event mapper with matchAll=true must be listed last. Otherwise, some mappers would be ignored.");
       }
     } catch (IOException | IllegalArgumentException e) {
       throw new ConfigException("Invalid custom application event mapping JSON", e);

--- a/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkConnectorConfig.java
+++ b/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkConnectorConfig.java
@@ -65,9 +65,12 @@ public class ScalyrSinkConnectorConfig extends AbstractConfig {
     + BATCH_SEND_SIZE_BYTES_CONFIG + " may not be reached for longer periods of time.";
   public static final String CUSTOM_APP_EVENT_MAPPING_CONFIG = "custom_app_event_mapping";
   private static final String CUSTOM_APP_EVENT_MAPPING_DOC = "JSON config describing how to map custom application nested Kafka messages to Scalyr events." +
-    "  Multiple custom application event mappings can be specified in a JSON list.  Example config JSON:\n"
-    + "[{\"matcher\": { \"attribute\": \"app.name\", \"value\": \"customApp\"},\n" +
-    " \"eventMapping\": { \"message\": \"message\", \"logfile\": \"log.path\", \"serverHost\": \"host.hostname\", \"parser\": \"fields.parser\", \"version\": \"app.version\"} }]";
+    "  Multiple custom application event mappings can be specified in a JSON list and are evaluated in the order specified in the list." +
+    "  Regex is supported for the matcher.value.  Example config JSON:\n" +
+    "[{\"matcher\": { \"attribute\": \"app.name\", \"value\": \"mpApp.*\"},\n" +
+    " \"eventMapping\": { \"message\": \"message\", \"logfile\": \"log.path\", \"serverHost\": \"host.hostname\", \"parser\": \"fields.parser\", \"version\": \"app.version\"} },\n" +
+    "{\"matcher\": { \"matchAll\": true},\n" +
+    " \"eventMapping\": { \"message\": \"message\", \"logfile\": \"log.path\", \"serverHost\": \"host.hostname\", \"parser\": \"fields.parser\"} }]";
   public static final String SEND_ENTIRE_RECORD = "send_entire_record";
   private static final String SEND_ENTIRE_RECORD_DOC = "If true, send the entire Kafka Connect record value serialized to JSON as the message field.";
 

--- a/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkTask.java
+++ b/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkTask.java
@@ -166,7 +166,6 @@ public class ScalyrSinkTask extends SinkTask {
       if (noRecordLogRateLimiter.tryAcquire()) {
         log.warn("No records matched an event mapper.  Records not sent to Scalyr.  Check the custom_app_event_mapping matcher configuration.");
       }
-      return;
     }
 
     // Send events when batchSendWaitMs exceeded

--- a/src/main/java/com/scalyr/integrations/kafka/mapping/CustomAppEventMapping.java
+++ b/src/main/java/com/scalyr/integrations/kafka/mapping/CustomAppEventMapping.java
@@ -54,6 +54,15 @@ import java.util.stream.Collectors;
 
  `matcher` defines an attribute to determine whether the event mapping applies to the message.
  The event mapping is only applied to messages where the `matcher.attribute` value matches the `matcher.value`.
+ `matcher.value` can be a regex.
+
+ `matcher` can also be defined to match all events:
+ ```
+ "matcher": {
+   "matchAll": true
+ }
+ ```
+ When `matchAll=true`, `attribute` and `value` fields are not required and are ignored.
 
  `eventMapping` defines the message fields that are mapped to Scalyr event attributes.
  The attribute is the Scalyr event key.  The attribute value specifies the

--- a/src/main/java/com/scalyr/integrations/kafka/mapping/CustomAppEventMapping.java
+++ b/src/main/java/com/scalyr/integrations/kafka/mapping/CustomAppEventMapping.java
@@ -87,6 +87,7 @@ public class CustomAppEventMapping {
   public static final String LOG_FILE = "logfile";
   public static final String PARSER = "parser";
   public static final String MESSAGE = "message";
+  private static final String MATCHER_NOT_DEFINED_ERROR = "matcher not defined in custom application event mapping";
 
   private static final Set<String> standardAttrs = ImmutableSet.of(SERVER_HOST, LOG_FILE, PARSER, MESSAGE);
 
@@ -106,7 +107,7 @@ public class CustomAppEventMapping {
   }
 
   public String getMatcherValue() {
-    Preconditions.checkArgument(matcher != null, "matcher not defined in custom application event mapping");
+    Preconditions.checkArgument(matcher != null, MATCHER_NOT_DEFINED_ERROR);
     return matcher.value;
   }
 
@@ -115,13 +116,13 @@ public class CustomAppEventMapping {
    * using the delimiter as the field separator.
    */
   public List<String> getMatcherFields() {
-    Preconditions.checkArgument(matcher != null, "matcher not defined in custom application event mapping");
+    Preconditions.checkArgument(matcher != null, MATCHER_NOT_DEFINED_ERROR);
     return splitAttrFields(matcher.attribute);
   }
 
   public boolean isMatchAll() {
-    Preconditions.checkArgument(matcher != null, "matcher not defined in custom application event mapping");
-    return matcher.matchAll == null ? false : matcher.matchAll;
+    Preconditions.checkArgument(matcher != null, MATCHER_NOT_DEFINED_ERROR);
+    return matcher.matchAll;
   }
 
   public List<String> getServerHostFields() {
@@ -164,7 +165,7 @@ public class CustomAppEventMapping {
    * Defines the field and value to determine whether the message matches the custom app event mapping.
    */
   public static class Matcher {
-    private Boolean matchAll;
+    private boolean matchAll;
     private String attribute;
     private String value;
 

--- a/src/main/java/com/scalyr/integrations/kafka/mapping/CustomAppEventMapping.java
+++ b/src/main/java/com/scalyr/integrations/kafka/mapping/CustomAppEventMapping.java
@@ -81,16 +81,19 @@ public class CustomAppEventMapping {
 
   private static final Set<String> standardAttrs = ImmutableSet.of(SERVER_HOST, LOG_FILE, PARSER, MESSAGE);
 
-  public void setMatcher(Matcher matcher) {
+  public CustomAppEventMapping setMatcher(Matcher matcher) {
     this.matcher = matcher;
+    return this;
   }
 
-  public void setEventMapping(Map<String, String> eventMapping) {
+  public CustomAppEventMapping setEventMapping(Map<String, String> eventMapping) {
     this.eventMapping = eventMapping;
+    return this;
   }
 
-  public void setDelimiter(String fieldDelimiter) {
+  public CustomAppEventMapping setDelimiter(String fieldDelimiter) {
     this.delimiter = fieldDelimiter;
+    return this;
   }
 
   public String getMatcherValue() {

--- a/src/main/java/com/scalyr/integrations/kafka/mapping/CustomAppEventMapping.java
+++ b/src/main/java/com/scalyr/integrations/kafka/mapping/CustomAppEventMapping.java
@@ -110,6 +110,11 @@ public class CustomAppEventMapping {
     return splitAttrFields(matcher.attribute);
   }
 
+  public boolean isMatchAll() {
+    Preconditions.checkArgument(matcher != null, "matcher not defined in custom application event mapping");
+    return matcher.matchAll == null ? false : matcher.matchAll;
+  }
+
   public List<String> getServerHostFields() {
     return getAttribute(SERVER_HOST);
   }
@@ -150,15 +155,23 @@ public class CustomAppEventMapping {
    * Defines the field and value to determine whether the message matches the custom app event mapping.
    */
   public static class Matcher {
+    private Boolean matchAll;
     private String attribute;
     private String value;
 
-    public void setAttribute(String attribute) {
-      this.attribute = attribute;
+    public Matcher setMatchAll(Boolean matchAll) {
+      this.matchAll = matchAll;
+      return this;
     }
 
-    public void setValue(String value) {
+    public Matcher setAttribute(String attribute) {
+      this.attribute = attribute;
+      return this;
+    }
+
+    public Matcher setValue(String value) {
       this.value = value;
+      return this;
     }
 
     @Override

--- a/src/main/java/com/scalyr/integrations/kafka/mapping/CustomAppMessageMapper.java
+++ b/src/main/java/com/scalyr/integrations/kafka/mapping/CustomAppMessageMapper.java
@@ -34,6 +34,7 @@ public class CustomAppMessageMapper implements MessageMapper {
   private final List<String> matcherFields;
   private final Map<String, List<String>> additionalAttrsFields;
   private final Pattern matcherRegex;
+  private final boolean matchAll;
 
   /**
    * CustomApplicationDefinition fields are memoized to instance variables
@@ -45,8 +46,9 @@ public class CustomAppMessageMapper implements MessageMapper {
     serverHostFields = customAppEventMapping.getServerHostFields();
     parserFields = customAppEventMapping.getParserFields();
     matcherFields = customAppEventMapping.getMatcherFields();
+    matchAll = customAppEventMapping.isMatchAll();
     additionalAttrsFields = customAppEventMapping.getAdditionalAttrFields();
-    matcherRegex = Pattern.compile(customAppEventMapping.getMatcherValue());
+    matcherRegex = matchAll ? null : Pattern.compile(customAppEventMapping.getMatcherValue());
   }
 
   @Override
@@ -79,6 +81,10 @@ public class CustomAppMessageMapper implements MessageMapper {
 
   @Override
   public boolean matches(SinkRecord record) {
+    if (matchAll) {
+      return true;
+    }
+
     Object fieldValue = FieldExtractor.getField(record.value(), matcherFields);
     return fieldValue == null ? false : matcherRegex.matcher(fieldValue.toString()).matches();
   }

--- a/src/main/java/com/scalyr/integrations/kafka/mapping/CustomAppMessageMapper.java
+++ b/src/main/java/com/scalyr/integrations/kafka/mapping/CustomAppMessageMapper.java
@@ -47,8 +47,8 @@ public class CustomAppMessageMapper implements MessageMapper {
     parserFields = customAppEventMapping.getParserFields();
     matcherFields = customAppEventMapping.getMatcherFields();
     matchAll = customAppEventMapping.isMatchAll();
-    additionalAttrsFields = customAppEventMapping.getAdditionalAttrFields();
     matcherRegex = matchAll ? null : Pattern.compile(customAppEventMapping.getMatcherValue());
+    additionalAttrsFields = customAppEventMapping.getAdditionalAttrFields();
   }
 
   @Override

--- a/src/main/java/com/scalyr/integrations/kafka/mapping/CustomAppMessageMapper.java
+++ b/src/main/java/com/scalyr/integrations/kafka/mapping/CustomAppMessageMapper.java
@@ -21,6 +21,7 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Maps custom app messages to Scalyr events using {@link CustomAppEventMapping} event mapping definition.
@@ -32,7 +33,7 @@ public class CustomAppMessageMapper implements MessageMapper {
   private final List<String> parserFields;
   private final List<String> matcherFields;
   private final Map<String, List<String>> additionalAttrsFields;
-  private final String matcherValue;
+  private final Pattern matcherRegex;
 
   /**
    * CustomApplicationDefinition fields are memoized to instance variables
@@ -45,7 +46,7 @@ public class CustomAppMessageMapper implements MessageMapper {
     parserFields = customAppEventMapping.getParserFields();
     matcherFields = customAppEventMapping.getMatcherFields();
     additionalAttrsFields = customAppEventMapping.getAdditionalAttrFields();
-    matcherValue = customAppEventMapping.getMatcherValue();
+    matcherRegex = Pattern.compile(customAppEventMapping.getMatcherValue());
   }
 
   @Override
@@ -79,6 +80,6 @@ public class CustomAppMessageMapper implements MessageMapper {
   @Override
   public boolean matches(SinkRecord record) {
     Object fieldValue = FieldExtractor.getField(record.value(), matcherFields);
-    return matcherValue.equals(fieldValue);
+    return fieldValue == null ? false : matcherRegex.matcher(fieldValue.toString()).matches();
   }
 }

--- a/src/main/java/com/scalyr/integrations/kafka/mapping/EventMapper.java
+++ b/src/main/java/com/scalyr/integrations/kafka/mapping/EventMapper.java
@@ -34,7 +34,9 @@ import java.util.function.Supplier;
 /**
  * Converts a SinkRecord to a Scalyr Event.
  * Determines which {@link MessageMapper} to use and maps the SinkRecord to an Event using the
- * MessageMapper.
+ * MessageMapper.  MessageMappers are evaluated in the following order:
+ * 1. Scalyr supported message sources
+ * 2. Custom app event mappers in the order they are defined in connector config.
  */
 public class EventMapper {
   private static final Logger log = LoggerFactory.getLogger(EventMapper.class);

--- a/src/test/java/com/scalyr/integrations/kafka/TestValues.java
+++ b/src/test/java/com/scalyr/integrations/kafka/TestValues.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -74,11 +73,9 @@ public abstract class TestValues {
       ADD_EVENTS_RESPONSE_INPUT_TOO_LONG = objectMapper.writeValueAsString(new AddEventsClient.AddEventsResponse()
         .setStatus("error/client/badParam").setMessage("input too long (maximum 6000000 characters)"));
 
-      CUSTOM_APP_EVENT_MAPPING_JSON = objectMapper.writeValueAsString(Collections.singletonList(createCustomAppEventMapping(".")));
-      CUSTOM_APP_EVENT_MAPPING_WITH_DELIMITER_JSON = objectMapper.writeValueAsString(Collections.singletonList(createCustomAppEventMapping("_")));
-      final Map<String, Object> customAppEventMappingMatchAll = createCustomAppEventMapping(".");
-      customAppEventMappingMatchAll.put("matcher", ImmutableMap.of("matchAll", true));
-      CUSTOM_APP_MATCH_ALL_EVENT_MAPPING_JSON = objectMapper.writeValueAsString(Collections.singletonList(customAppEventMappingMatchAll));
+      CUSTOM_APP_EVENT_MAPPING_JSON = objectMapper.writeValueAsString(Collections.singletonList(createCustomAppEventMapping(".", false)));
+      CUSTOM_APP_EVENT_MAPPING_WITH_DELIMITER_JSON = objectMapper.writeValueAsString(Collections.singletonList(createCustomAppEventMapping("_", false)));
+      CUSTOM_APP_MATCH_ALL_EVENT_MAPPING_JSON = objectMapper.writeValueAsString(Collections.singletonList(createCustomAppEventMapping(".", true)));
 
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
@@ -88,11 +85,15 @@ public abstract class TestValues {
   /**
    * Create test custom app event mapping as data structure that can be serialized to JSON.
    */
-  public static Map<String, Object> createCustomAppEventMapping(String delimiter) {
+  public static Map<String, Object> createCustomAppEventMapping(String delimiter, boolean matchAll) {
     Map<String, Object> customAppEventMapper = new HashMap<>();
-    customAppEventMapper.put("matcher", TestUtils.makeMap(
-      "attribute", "application" + delimiter + "name",
-      "value", CUSTOM_APP_NAME));
+    if (matchAll) {
+      customAppEventMapper.put("matcher", ImmutableMap.of("matchAll", true));
+    } else {
+      customAppEventMapper.put("matcher", TestUtils.makeMap(
+        "attribute", "application" + delimiter + "name",
+        "value", CUSTOM_APP_NAME));
+    }
 
     customAppEventMapper.put("eventMapping", TestUtils.makeMap(
       "message", "message",

--- a/src/test/java/com/scalyr/integrations/kafka/TestValues.java
+++ b/src/test/java/com/scalyr/integrations/kafka/TestValues.java
@@ -19,6 +19,7 @@ package com.scalyr.integrations.kafka;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -57,6 +58,7 @@ public abstract class TestValues {
   public static final String ADD_EVENTS_RESPONSE_INPUT_TOO_LONG;
   public static final String CUSTOM_APP_EVENT_MAPPING_JSON;
   public static final String CUSTOM_APP_EVENT_MAPPING_WITH_DELIMITER_JSON;
+  public static final String CUSTOM_APP_MATCH_ALL_EVENT_MAPPING_JSON;
 
 
   static {
@@ -74,6 +76,10 @@ public abstract class TestValues {
 
       CUSTOM_APP_EVENT_MAPPING_JSON = objectMapper.writeValueAsString(Collections.singletonList(createCustomAppEventMapping(".")));
       CUSTOM_APP_EVENT_MAPPING_WITH_DELIMITER_JSON = objectMapper.writeValueAsString(Collections.singletonList(createCustomAppEventMapping("_")));
+      final Map<String, Object> customAppEventMappingMatchAll = createCustomAppEventMapping(".");
+      customAppEventMappingMatchAll.put("matcher", ImmutableMap.of("matchAll", true));
+      CUSTOM_APP_MATCH_ALL_EVENT_MAPPING_JSON = objectMapper.writeValueAsString(Collections.singletonList(customAppEventMappingMatchAll));
+
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/com/scalyr/integrations/kafka/mapping/CustomAppEventMappingTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/mapping/CustomAppEventMappingTest.java
@@ -46,7 +46,7 @@ public class CustomAppEventMappingTest {
   @Test
   public void testUndefinedFields() throws IOException {
     // Create event mapping with missing Scalyr fields
-    Map<String, Object> customAppEventMappingDefinition = TestValues.createCustomAppEventMapping(".");
+    Map<String, Object> customAppEventMappingDefinition = TestValues.createCustomAppEventMapping(".", false);
     ((Map)customAppEventMappingDefinition.get("eventMapping")).remove("logfile");
     ((Map)customAppEventMappingDefinition.get("eventMapping")).remove("parser");
 

--- a/src/test/java/com/scalyr/integrations/kafka/mapping/CustomAppEventMappingTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/mapping/CustomAppEventMappingTest.java
@@ -22,15 +22,23 @@ public class CustomAppEventMappingTest {
   public void testDeserializationDefaultDelimiter() throws IOException {
     List<CustomAppEventMapping> customAppEventMappings = CustomAppEventMapping.parseCustomAppEventMappingConfig(TestValues.CUSTOM_APP_EVENT_MAPPING_JSON);
     assertEquals(1, customAppEventMappings.size());
-    verifyCustomApplicationEventMapping(customAppEventMappings.get(0));
+    verifyCustomApplicationEventMapping(customAppEventMappings.get(0), false);
   }
 
   @Test
   public void testDeserializationCustomDelimiter() throws IOException {
     List<CustomAppEventMapping> customAppEventMappings = CustomAppEventMapping.parseCustomAppEventMappingConfig(TestValues.CUSTOM_APP_EVENT_MAPPING_WITH_DELIMITER_JSON);
     assertEquals(1, customAppEventMappings.size());
-    verifyCustomApplicationEventMapping(customAppEventMappings.get(0));
+    verifyCustomApplicationEventMapping(customAppEventMappings.get(0), false);
   }
+
+  @Test
+  public void testDeserializationMatchAll() throws IOException {
+    List<CustomAppEventMapping> customAppEventMappings = CustomAppEventMapping.parseCustomAppEventMappingConfig(TestValues.CUSTOM_APP_MATCH_ALL_EVENT_MAPPING_JSON);
+    assertEquals(1, customAppEventMappings.size());
+    verifyCustomApplicationEventMapping(customAppEventMappings.get(0), true);
+  }
+
 
   /**
    * Verify undefined fields in event mapping return empty list for fields.
@@ -54,9 +62,12 @@ public class CustomAppEventMappingTest {
   /**
    * Verify JSON is parsed correctly to CustomAppEventMapping
    */
-  private void verifyCustomApplicationEventMapping(CustomAppEventMapping customAppEventMapping) {
-    assertEquals(ImmutableList.of("application", "name"), customAppEventMapping.getMatcherFields());
-    assertEquals(TestValues.CUSTOM_APP_NAME, customAppEventMapping.getMatcherValue());
+  private void verifyCustomApplicationEventMapping(CustomAppEventMapping customAppEventMapping, boolean isMatchAll) {
+    assertEquals(isMatchAll, customAppEventMapping.isMatchAll());
+    if (!isMatchAll) {
+      assertEquals(ImmutableList.of("application", "name"), customAppEventMapping.getMatcherFields());
+      assertEquals(TestValues.CUSTOM_APP_NAME, customAppEventMapping.getMatcherValue());
+    }
     assertEquals(ImmutableList.of("message"), customAppEventMapping.getMessageFields());
     assertEquals(ImmutableList.of("application", "name"), customAppEventMapping.getLogfileFields());
     assertEquals(ImmutableList.of("host", "hostname"), customAppEventMapping.getServerHostFields());

--- a/src/test/java/com/scalyr/integrations/kafka/mapping/CustomAppMessageMapperTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/mapping/CustomAppMessageMapperTest.java
@@ -50,6 +50,7 @@ public class CustomAppMessageMapperTest {
   private static final Random random = new Random();
   private MessageMapper messageMapper;
   private SinkRecordValueCreator sinkRecordValueCreator;
+  private boolean matchAll;
 
   private static final String topic = "test-topic";
   private static final int partition = 0;
@@ -57,13 +58,15 @@ public class CustomAppMessageMapperTest {
 
   @Parameterized.Parameters
   public static Collection<Object[]> testParams() {
-    return Arrays.asList(new Object[][] { {createCustomAppEventMapping()},
-      {createCustomAppEventMapping().setMatcher(createMatcher(matcherAttr, "custom.*"))}});
+    return Arrays.asList(new Object[][] { {createCustomAppEventMapping(), false},
+      {createCustomAppEventMapping().setMatcher(createMatcher(matcherAttr, "custom.*")), false},
+      {createCustomAppEventMapping().setMatcher(new CustomAppEventMapping.Matcher().setMatchAll(true)), true}});
   }
 
-  public CustomAppMessageMapperTest(CustomAppEventMapping customAppEventMapping) {
-    messageMapper = new CustomAppMessageMapper(customAppEventMapping);
-    sinkRecordValueCreator = new CustomAppRecordValueCreator();
+  public CustomAppMessageMapperTest(CustomAppEventMapping customAppEventMapping, boolean matchAll) {
+    this.messageMapper = new CustomAppMessageMapper(customAppEventMapping);
+    this.matchAll = matchAll;
+    this.sinkRecordValueCreator = new CustomAppRecordValueCreator();
 
   }
 
@@ -144,7 +147,7 @@ public class CustomAppMessageMapperTest {
     assertNull(messageMapper.getLogfile(record));
     assertNull(messageMapper.getParser(record));
     assertNull(messageMapper.getServerHost(record));
-    assertFalse(messageMapper.matches(record));
+    assertEquals(matchAll, messageMapper.matches(record));
     Map<String, Object> additionalAttrs = messageMapper.getAdditionalAttrs(record);
     assertTrue(additionalAttrs.containsKey("id"));
     assertTrue(additionalAttrs.containsKey("severity"));


### PR DESCRIPTION
Made the following changes:
1. Short-circuit out of sendEvents if there is nothing to send; sending empty ingestion batches to the Scalyr backend is confusing/misleading.
2. Add rate-limited logging when event mappers do not match any events.
3. Support wildcards in the matcher rules config.  We can now support regex for the `matcher.value`.
e.g.
```
[{
    "matcher": {
        "attribute": "env",
        "value": "staging-.*"
    },
    "eventMapping": {
       ...
    }
}]
```
4. Support a "match all" for custom event mapping matcher, so that custom app event mapper can easily be applied to all events in the topic.  Match all is specified as:
```
 "matcher": {
       "matchAll":"true",
    },
```
`attribute` and `value` fields do not need to be defined when `matchAll: true`.

Custom app event mappings are evaluated in the order defined in the JSON.  The first one that matches is chosen.  To avoid ambiguity when matching custom app event mappers with `matchAll:true`, the following rules are enforced n the config validator:
1. Only one event mapping with `matchAll:true` should be defined.
2. Event mapping with `matchAll:true` should be defined as the last event mapping, so that other event mappers can match.

Better to review by commit.
