### PR TITLE
CT-279 Use netty-based AsyncHttpClient in AddEventsClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,16 +37,6 @@
             <version>6.0.19</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.12</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <version>4.4.13</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.10.3</version>
@@ -60,6 +50,11 @@
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
             <version>1.4.4-9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.asynchttpclient</groupId>
+            <artifactId>async-http-client</artifactId>
+            <version>2.12.1</version>
         </dependency>
         <!-- Test dependencies -->
         <dependency>

--- a/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
+++ b/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
@@ -31,25 +31,22 @@ import com.google.common.io.CountingOutputStream;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.scalyr.api.internal.ScalyrUtil;
-import org.apache.http.HttpStatus;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.entity.ByteArrayEntity;
-import org.apache.http.entity.ContentType;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.BoundRequestBuilder;
+import org.asynchttpclient.ListenableFuture;
+import org.asynchttpclient.Response;
+import org.asynchttpclient.uri.Uri;
+import org.asynchttpclient.util.HttpConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import javax.ws.rs.core.MediaType;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,6 +57,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.LongConsumer;
+
+import static org.asynchttpclient.Dsl.*;
 
 /**
  * AddEventsClients provides abstraction for making Scalyr addEvents API calls.
@@ -74,10 +73,10 @@ public class AddEventsClient implements AutoCloseable {
   // Separate logger which is used for logging the whole payload when the payload exceeds the limit
   private static final Logger payloadLogger = LoggerFactory.getLogger("com.scalyr.integrations.kafka.eventpayload");
 
-  private final CloseableHttpClient client = HttpClients.createDefault();
+  private static final AsyncHttpClient asyncHttpClient = asyncHttpClient();
   private final ObjectMapper objectMapper = new ObjectMapper();
-  private final ExecutorService senderThread = Executors.newSingleThreadExecutor();
-  private final HttpPost httpPost;
+  private final ExecutorService retryThread = Executors.newSingleThreadExecutor();
+  private final BoundRequestBuilder requestBuilder;
   private final String apiKey;
   private final long addEventsTimeoutMs;
   private final int initialBackoffDelayMs;
@@ -128,7 +127,7 @@ public class AddEventsClient implements AutoCloseable {
     this.initialBackoffDelayMs = initialBackoffDelayMs;
     this.compressor = compressor;
     this.sleep = sleep != null ? sleep : timeMs -> Uninterruptibles.sleepUninterruptibly(timeMs, TimeUnit.MILLISECONDS);
-    this.httpPost = new HttpPost(buildAddEventsUri(scalyrUrl));
+    this.requestBuilder = asyncHttpClient.preparePost(buildAddEventsUri(scalyrUrl));
     addHeaders();
   }
 
@@ -176,7 +175,9 @@ public class AddEventsClient implements AutoCloseable {
       }
 
       final byte[] addEventsPayload = outputStream.toByteArray();
-      return CompletableFuture.supplyAsync(() -> addEventsWithRetry(addEventsPayload, uncompressedPayloadSize, startTimeMs), senderThread);
+      CompletableFuture<AddEventsResponse> addEventsResult = new CompletableFuture<>();
+      addEventsWithRetry(addEventsPayload, uncompressedPayloadSize, addEventsResult, startTimeMs, initialBackoffDelayMs);
+      return addEventsResult;
     } catch (Exception e) {
       log.warn("AddEventsClient.log error", e);
       CompletableFuture<AddEventsResponse> errorFuture = new CompletableFuture<>();
@@ -193,13 +194,18 @@ public class AddEventsClient implements AutoCloseable {
   }
 
   /**
-   * Call Scalyr addEvents API with {@link #addEventsTimeoutMs} using exponential backoff.
+   * Call Scalyr addEvents API with {@link #addEventsTimeoutMs} using exponential backoff retries.
+   * Retries are triggered async when the async add events call completes by recursively calling this method.
+   * Result is returned by completing the `addEventsResult` future with the result.
+   *
    * @param addEventsPayload byte[] addEvents payload (post compression if compression is enabled).
    * @param uncompressedPayloadSize long raw serialized JSON addEvents payload size before the compression.
+   * @param addEventsResult CompletableFuture to return add events result in.
    * @param startTimeMs time in ms from epoch when `log` is called.  Used to enforce `addEventsTimeoutMs` deadline.
-   * @return AddEventsResponse
+   * @param retryDelayMs time in ms to delay retry
    */
-  private AddEventsResponse addEventsWithRetry(byte[] addEventsPayload, long uncompressedPayloadSize, long startTimeMs) {
+  private void addEventsWithRetry(byte[] addEventsPayload, long uncompressedPayloadSize, CompletableFuture<AddEventsResponse> addEventsResult,
+      long startTimeMs, int retryDelayMs) {
     log.debug("addEvents payload uncompressed size {} bytes, compressed size {} bytes", uncompressedPayloadSize, addEventsPayload.length);
 
     // 6 MB add events payload exceeded.  Log the issue and skip this message.
@@ -215,47 +221,53 @@ public class AddEventsClient implements AutoCloseable {
         byte[] decompressedPayload = getDecompressedPayload(addEventsPayload);
         payloadLogger.error("Add events too large payload: {}", new String(decompressedPayload));
       }
-      return PAYLOAD_TOO_LARGE;
+      addEventsResult.complete(PAYLOAD_TOO_LARGE);
+      return;
     }
 
-    AddEventsResponse addEventsResponse = TIMEOUT_ADD_EVENTS_RESPONSE;
-    long delayTimeMs = initialBackoffDelayMs;
-    httpPost.setEntity(new ByteArrayEntity(addEventsPayload));
+    // Retries timed out
+    if (remainingMs(startTimeMs) == 0) {
+      addEventsResult.complete(TIMEOUT_ADD_EVENTS_RESPONSE);
+      return;
+    }
 
-    boolean shouldCallAddEvents = remainingMs(startTimeMs) > 0;
-    while (shouldCallAddEvents) {
-      try (CloseableHttpResponse httpResponse = client.execute(httpPost)) {
-        addEventsResponse = parseAddEventsResponse(httpResponse);
-        log.debug("post http code {}, httpResponse {}", httpResponse.getStatusLine().getStatusCode(), addEventsResponse);
-        // return on success or non-retriable error
+    requestBuilder.setBody(addEventsPayload);
+    final ListenableFuture<Response> addEventsFuture = requestBuilder.execute();
+    addEventsFuture.addListener(() -> {
+      AddEventsResponse addEventsResponse;
+      try {
+        final Response response = addEventsFuture.get();
+        addEventsResponse = parseAddEventsResponse(response);
+        log.debug("post http code {}, httpResponse {}", response.getStatusCode(), addEventsResponse);
         if (addEventsResponse.isSuccess() || !addEventsResponse.isRetriable()) {
-          return addEventsResponse;
+          addEventsResult.complete(addEventsResponse);
+          return;
         }
-      } catch (IOException e) {
-        log.warn("Error calling Scalyr addEvents API", e);
-        addEventsResponse = new AddEventsResponse().setStatus("IOException").setMessage(e.toString());
+      } catch (Exception e) {
+        Throwable rootCauseException = e.getCause() == null ? e : e.getCause();
+        addEventsResponse = new AddEventsResponse().setStatus("addEvents error").setMessage(rootCauseException.toString());
       }
 
-      shouldCallAddEvents = remainingMs(startTimeMs) > delayTimeMs;
-      if (shouldCallAddEvents) {
-        sleep.accept(delayTimeMs);
-        delayTimeMs = delayTimeMs * 2;
+      // error - retry if not timed out and retriable, otherwise, complete with failure
+      log.warn("addEvents failed with {}", addEventsResponse);
+      if (remainingMs(startTimeMs) > retryDelayMs && addEventsResponse.isRetriable()) {
+        sleep.accept(retryDelayMs);
+        addEventsWithRetry(addEventsPayload, uncompressedPayloadSize, addEventsResult, startTimeMs, retryDelayMs * 2);
+      } else {
+        addEventsResult.complete(addEventsResponse);
       }
-    }
-
-    return addEventsResponse;
+    }, retryThread);
   }
 
   /**
-   * Convert httpResponse into AddEventsResponse, handling different error conditions.
-   * @param httpResponse HTTP response from the addEvents call
+   * Convert Response into AddEventsResponse, handling different error conditions.
+   * @param response Response from the addEvents call
    * @return AddEventsResponse
    */
-  private AddEventsResponse parseAddEventsResponse(CloseableHttpResponse httpResponse) {
-    final int statusCode = httpResponse.getStatusLine().getStatusCode();
-    final long responseLength = httpResponse.getEntity().getContentLength();
+  private AddEventsResponse parseAddEventsResponse(Response response) {
+    final int statusCode = response.getStatusCode();
 
-    if (responseLength == 0) {
+    if (!response.hasResponseBody()) {
       log.warn("addEvents received empty response, server may have reset connection.");
       return new AddEventsResponse().setStatus("emptyResponse");
     }
@@ -266,10 +278,10 @@ public class AddEventsClient implements AutoCloseable {
     }
 
     try {
-      AddEventsResponse addEventsResponse = objectMapper.readValue(httpResponse.getEntity().getContent(), AddEventsResponse.class);
+      AddEventsResponse addEventsResponse = objectMapper.readValue(response.getResponseBodyAsBytes(), AddEventsResponse.class);
 
       // Success
-      if (statusCode == HttpStatus.SC_OK && addEventsResponse.isSuccess()) {
+      if (statusCode == HttpConstants.ResponseStatusCodes.OK_200 && addEventsResponse.isSuccess()) {
         return addEventsResponse;
       }
 
@@ -312,31 +324,26 @@ public class AddEventsClient implements AutoCloseable {
    * @return Scalyr addEvents URI.  e.g. https://apps.scalyr.com/addEvents
    * @throws IllegalArgumentException with invalid Scalyr URL
    */
-  private URI buildAddEventsUri(String url) {
-    try {
-      URIBuilder urlBuilder = new URIBuilder(url);
+  private String buildAddEventsUri(String url) {
+      Uri uri = Uri.create(url);
 
       // Enforce https for Scalyr connection
-      Preconditions.checkArgument((urlBuilder.getScheme() != null && urlBuilder.getHost() != null)
-        && ((!"localhost".equals(urlBuilder.getHost()) && "https".equals(urlBuilder.getScheme())) || "localhost".equals(urlBuilder.getHost())),
+      Preconditions.checkArgument((uri.getScheme() != null && uri.getHost() != null)
+        && ((!"localhost".equals(uri.getHost()) && Uri.HTTPS.equals(uri.getScheme())) || "localhost".equals(uri.getHost())),
         "Invalid Scalyr URL: {}", url);
 
-      urlBuilder.setPath("addEvents");
-      return  urlBuilder.build();
-    } catch (URISyntaxException e) {
-      throw new IllegalArgumentException(e);
-    }
+      return new Uri(uri.getScheme(), null, uri.getHost(), uri.getPort(), "/addEvents", null, null).toFullUrl();
   }
 
   /**
    * Add addEvents POST request headers
    */
   private void addHeaders() {
-    httpPost.addHeader("Content-type", ContentType.APPLICATION_JSON.toString());
-    httpPost.addHeader("Accept", ContentType.APPLICATION_JSON.toString());
-    httpPost.addHeader("Connection", "Keep-Alive");
-    httpPost.addHeader("User-Agent", USER_AGENT);
-    httpPost.addHeader("Content-Encoding", compressor.getContentEncoding());
+    requestBuilder.addHeader("Content-type", MediaType.APPLICATION_JSON);
+    requestBuilder.addHeader("Accept", MediaType.APPLICATION_JSON);
+    requestBuilder.addHeader("Connection", "Keep-Alive");
+    requestBuilder.addHeader("User-Agent", USER_AGENT);
+    requestBuilder.addHeader("Content-Encoding", compressor.getContentEncoding());
   }
 
   /**
@@ -350,7 +357,7 @@ public class AddEventsClient implements AutoCloseable {
   @Override
   public void close() {
     try {
-      client.close();
+      asyncHttpClient.close();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkConnector.java
+++ b/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkConnector.java
@@ -58,6 +58,7 @@ public class ScalyrSinkConnector extends SinkConnector {
     }
 
     this.configProps = Collections.unmodifiableMap(configProps);
+    AddEventsClient.HttpWrapper.start();
     log.info("Started ScalyrSinkConnector");
   }
 
@@ -80,9 +81,9 @@ public class ScalyrSinkConnector extends SinkConnector {
 
   /**
    * Stop this connector.
-   * No actions needed.
    */
   @Override public void stop() {
+    AddEventsClient.HttpWrapper.stop();
     log.info("Stopped ScalyrSinkConnector");
   }
 

--- a/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkTask.java
+++ b/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkTask.java
@@ -243,9 +243,6 @@ public class ScalyrSinkTask extends SinkTask {
    */
   @Override
   public void stop() {
-    if (addEventsClient != null) {
-      addEventsClient.close();
-    }
     log.info("Stopped ScalyrSinkTask");
   }
 

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -30,6 +30,7 @@ import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -92,6 +93,11 @@ public class AddEventsClientTest {
   private String scalyrUrl;
   private Compressor compressor;
   private Compressor deflateCompressor;
+
+  @BeforeClass
+  public static void setupResources() {
+    AddEventsClient.HttpWrapper.start();
+  }
 
   @Before
   public void setup() {

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -52,7 +52,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static com.scalyr.integrations.kafka.TestUtils.fails;
-import static com.scalyr.integrations.kafka.TestUtils.MockSleep;
+import static com.scalyr.integrations.kafka.TestUtils.MockRunWithDelay;
 import static com.scalyr.integrations.kafka.TestValues.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -258,49 +258,49 @@ public class AddEventsClientTest {
   @Test
   public void testAddEventsClientErrors() throws Exception {
     int requestCount = 0;
-    MockSleep mockSleep = new MockSleep();
-    AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor, mockSleep.sleep);
+    MockRunWithDelay mockRunWithDelay = new MockRunWithDelay();
+    AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor, mockRunWithDelay.runWithDelay);
 
     // Server Too Busy
     TestUtils.addMockResponseWithRetries(server, new MockResponse().setResponseCode(429).setBody(ADD_EVENTS_RESPONSE_SERVER_BUSY));
     AddEventsResponse addEventsResponse = addEventsClient.log(TestUtils.createTestEvents(1, 1, 1, 1)).get(5, TimeUnit.SECONDS);
     assertEquals("serverTooBusy", addEventsResponse.getStatus());
     assertEquals(requestCount += EXPECTED_NUM_RETRIES, server.getRequestCount());
-    assertEquals(EXPECTED_SLEEP_TIME_MS, mockSleep.sleepTime.get());
+    assertEquals(EXPECTED_DELAY_TIME_MS, mockRunWithDelay.delayTime.get());
 
     // Client Bad Request
-    mockSleep.reset();
+    mockRunWithDelay.reset();
     server.enqueue(new MockResponse().setResponseCode(200).setBody(ADD_EVENTS_RESPONSE_CLIENT_BAD_PARAM));
     addEventsResponse = addEventsClient.log(TestUtils.createTestEvents(1, 1, 1, 1)).get(5, TimeUnit.SECONDS);
     assertEquals(AddEventsResponse.CLIENT_BAD_PARAM, addEventsResponse.getStatus());
     assertEquals(++requestCount, server.getRequestCount());
-    assertEquals(0, mockSleep.sleepTime.get());
+    assertEquals(0, mockRunWithDelay.delayTime.get());
 
     // Input too long
-    mockSleep.reset();
+    mockRunWithDelay.reset();
     server.enqueue(new MockResponse().setResponseCode(200).setBody(ADD_EVENTS_RESPONSE_INPUT_TOO_LONG));
     addEventsResponse = addEventsClient.log(TestUtils.createTestEvents(1, 1, 1, 1)).get(5, TimeUnit.SECONDS);
     assertTrue(addEventsResponse.isSuccess());
     assertTrue(addEventsResponse.hasIgnorableError());
     assertFalse(addEventsResponse.isRetriable());
     assertEquals(++requestCount, server.getRequestCount());
-    assertEquals(0, mockSleep.sleepTime.get());
+    assertEquals(0, mockRunWithDelay.delayTime.get());
 
     // Empty Response
-    mockSleep.reset();
+    mockRunWithDelay.reset();
     TestUtils.addMockResponseWithRetries(server, new MockResponse().setResponseCode(200).setBody(""));
     addEventsResponse = addEventsClient.log(TestUtils.createTestEvents(1, 1, 1, 1)).get(5, TimeUnit.SECONDS);
     assertEquals("emptyResponse", addEventsResponse.getStatus());
     assertEquals(requestCount + EXPECTED_NUM_RETRIES, server.getRequestCount());
-    assertEquals(EXPECTED_SLEEP_TIME_MS, mockSleep.sleepTime.get());
+    assertEquals(EXPECTED_DELAY_TIME_MS, mockRunWithDelay.delayTime.get());
 
     // IOException
     // Doesn't actually hit MockHttpServer, so cannot advance MockableTimer.
-    mockSleep.reset();
-    addEventsClient = new AddEventsClient("http://localhost", API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor, mockSleep.sleep);
+    mockRunWithDelay.reset();
+    addEventsClient = new AddEventsClient("http://localhost", API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor, mockRunWithDelay.runWithDelay);
     addEventsResponse = addEventsClient.log(TestUtils.createTestEvents(1, 1, 1, 1)).get(5, TimeUnit.MINUTES);
     assertEquals("addEvents error", addEventsResponse.getStatus());
-    assertEquals(EXPECTED_SLEEP_TIME_MS, mockSleep.sleepTime.get());
+    assertEquals(EXPECTED_DELAY_TIME_MS, mockRunWithDelay.delayTime.get());
   }
 
   /**
@@ -354,8 +354,8 @@ public class AddEventsClientTest {
    */
   @Test
   public void testDependentRequestsError() throws Exception {
-    MockSleep mockSleep = new MockSleep();
-    AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor, mockSleep.sleep);
+    MockRunWithDelay mockRunWithDelay = new MockRunWithDelay();
+    AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor, mockRunWithDelay.runWithDelay);
 
     // MockWebServer response with server busy response for first request
     TestUtils.addMockResponseWithRetries(server, new MockResponse().setResponseCode(429).setBody(ADD_EVENTS_RESPONSE_SERVER_BUSY));
@@ -369,7 +369,7 @@ public class AddEventsClientTest {
     assertEquals(addEventsResponse1, addEventsResponse2);
     assertFalse(addEventsResponse1.isSuccess());
     assertEquals(EXPECTED_NUM_RETRIES, server.getRequestCount());
-    assertEquals(EXPECTED_SLEEP_TIME_MS, mockSleep.sleepTime.get());
+    assertEquals(EXPECTED_DELAY_TIME_MS, mockRunWithDelay.delayTime.get());
   }
 
   /**
@@ -387,12 +387,12 @@ public class AddEventsClientTest {
   }
 
   /**
-   * Test retries without fake clock, which will cause the retry logic to sleep during retries.
+   * Test retries without mock retryWithDelay, which will cause the retry logic to delay during retries.
    * This test should not be run as part of the automated unit tests because it is slow.
    */
   @Ignore("Test is slow and should not be included in automated testing")
   @Test
-  public void testRetryWithoutFakeClock() throws Exception {
+  public void testRetryWithoutMockRetryWithDelay() throws Exception {
     AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor);
 
     // Server Too Busy

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -26,7 +26,6 @@ import okhttp3.Headers;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.apache.http.entity.ContentType;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.junit.After;
@@ -34,6 +33,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import javax.ws.rs.core.MediaType;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -293,7 +293,7 @@ public class AddEventsClientTest {
     mockSleep.reset();
     addEventsClient = new AddEventsClient("http://localhost", API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor, mockSleep.sleep);
     addEventsResponse = addEventsClient.log(TestUtils.createTestEvents(1, 1, 1, 1)).get(5, TimeUnit.MINUTES);
-    assertEquals("IOException", addEventsResponse.getStatus());
+    assertEquals("addEvents error", addEventsResponse.getStatus());
     assertEquals(EXPECTED_SLEEP_TIME_MS, mockSleep.sleepTime.get());
   }
 
@@ -564,8 +564,8 @@ public class AddEventsClientTest {
    * Verify HTTP request headers are set correctly.
    */
   private void verifyHeaders(Headers headers, Compressor compressor) {
-    assertEquals(ContentType.APPLICATION_JSON.toString(), headers.get("Content-type"));
-    assertEquals(ContentType.APPLICATION_JSON.toString(), headers.get("Accept"));
+    assertEquals(MediaType.APPLICATION_JSON, headers.get("Content-type"));
+    assertEquals(MediaType.APPLICATION_JSON, headers.get("Accept"));
     assertEquals("Keep-Alive", headers.get("Connection"));
     assertEquals(expectedUserAgent, headers.get("User-Agent"));
     assertEquals(compressor.getContentEncoding(), headers.get("Content-Encoding"));

--- a/src/test/java/com/scalyr/integrations/kafka/ScalyrSinkTaskTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/ScalyrSinkTaskTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -507,6 +508,7 @@ public class ScalyrSinkTaskTest {
   /**
    * Verify stop doesn't throw any exceptions
    */
+  @Ignore("Test closes AddEventsClient AsyncHttpClient, which causes subsequent tests to fail")
   @Test
   public void testStop() {
     Map<String, String> config = createConfig();

--- a/src/test/java/com/scalyr/integrations/kafka/ScalyrSinkTaskTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/ScalyrSinkTaskTest.java
@@ -31,7 +31,6 @@ import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -207,8 +206,8 @@ public class ScalyrSinkTaskTest {
     assumeFalse(sendEntireRecord);
     final int numRequests = 3;
     int requestCount = 0;
-    TestUtils.MockSleep mockSleep = new TestUtils.MockSleep();
-    this.scalyrSinkTask = new ScalyrSinkTask(mockSleep.sleep);
+    TestUtils.MockRunWithDelay mockRunWithDelay = new TestUtils.MockRunWithDelay();
+    this.scalyrSinkTask = new ScalyrSinkTask(mockRunWithDelay.runWithDelay);
     MockWebServer server = new MockWebServer();
 
     startTask(server);
@@ -219,7 +218,7 @@ public class ScalyrSinkTaskTest {
     scalyrSinkTask.put(records);
     scalyrSinkTask.waitForRequestsToComplete();
     assertEquals(requestCount += TestValues.EXPECTED_NUM_RETRIES, server.getRequestCount());
-    assertEquals(TestValues.EXPECTED_SLEEP_TIME_MS, mockSleep.sleepTime.get());
+    assertEquals(TestValues.EXPECTED_DELAY_TIME_MS, mockRunWithDelay.delayTime.get());
 
     // Additional requests should have errors
     final int currentRequestCount = requestCount;
@@ -242,10 +241,10 @@ public class ScalyrSinkTaskTest {
    * Verify that input too long error is ignored
    */
   @Test
-  public void testIgnoreInputTooLongError() throws Exception {
+  public void testIgnoreInputTooLongError() {
     assumeFalse(sendEntireRecord);
-    TestUtils.MockSleep mockSleep = new TestUtils.MockSleep();
-    this.scalyrSinkTask = new ScalyrSinkTask(mockSleep.sleep);
+    TestUtils.MockRunWithDelay mockRunWithDelay = new TestUtils.MockRunWithDelay();
+    this.scalyrSinkTask = new ScalyrSinkTask(mockRunWithDelay.runWithDelay);
     MockWebServer server = new MockWebServer();
 
     startTask(server);
@@ -257,7 +256,7 @@ public class ScalyrSinkTaskTest {
     scalyrSinkTask.flush(Collections.emptyMap());
     scalyrSinkTask.waitForRequestsToComplete();
     assertEquals(2, server.getRequestCount());
-    assertEquals(0, mockSleep.sleepTime.get());
+    assertEquals(0, mockRunWithDelay.delayTime.get());
 
     // Subsequent requests should succeed
     IntStream.range(0, 2).forEach(i -> server.enqueue(new MockResponse().setResponseCode(200).setBody(TestValues.ADD_EVENTS_RESPONSE_SUCCESS)));

--- a/src/test/java/com/scalyr/integrations/kafka/ScalyrSinkTaskTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/ScalyrSinkTaskTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -88,6 +89,11 @@ public class ScalyrSinkTaskTest {
     Object data = recordValue.apply(1, 1, 1);
     System.out.println("Executing test with " + (data instanceof Struct ? "schema" : "schemaless") + " recordValue: " + data);
 
+  }
+
+  @BeforeClass
+  public static void setupResources() {
+    AddEventsClient.HttpWrapper.start();
   }
 
   @Before
@@ -508,7 +514,6 @@ public class ScalyrSinkTaskTest {
   /**
    * Verify stop doesn't throw any exceptions
    */
-  @Ignore("Test closes AddEventsClient AsyncHttpClient, which causes subsequent tests to fail")
   @Test
   public void testStop() {
     Map<String, String> config = createConfig();

--- a/src/test/java/com/scalyr/integrations/kafka/TestUtils.java
+++ b/src/test/java/com/scalyr/integrations/kafka/TestUtils.java
@@ -39,7 +39,7 @@ import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.LongConsumer;
+import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -250,35 +250,36 @@ public class TestUtils {
   }
 
   /**
-   * Mock sleep implementation.
-   * Tracks total time slept so sleep time and be verified
+   * Mock runWithDelay implementation.
+   * Tracks total time delayed so delay time can be verified
    * and advances the ScalyrUtil mockable timer to simulate time advancing.
    */
-  public static class MockSleep {
+  public static class MockRunWithDelay {
 
     /**
-     * Total time slept
+     * Total time delayed
      */
-    public final AtomicLong sleepTime = new AtomicLong();
+    public final AtomicLong delayTime = new AtomicLong();
 
     /**
-     * Sleep lambda should be called in place of actual sleep
+     * runWithDelay lambda should be called in simulate delay and running task
      */
-    public final LongConsumer sleep = (timeMs) -> {
-      sleepTime.addAndGet(timeMs);
+    public final BiConsumer<Integer, Runnable> runWithDelay = (timeMs, task) -> {
+      delayTime.addAndGet(timeMs);
       ScalyrUtil.advanceCustomTimeMs(timeMs);
+      task.run();
     };
 
-    public MockSleep() {
+    public MockRunWithDelay() {
       ScalyrUtil.setCustomTimeNs(0);
     }
 
     /**
-     * Resets the total sleep time and mockable clock.
-     * Should be called each time a new sleep duration needs to be measured.
+     * Resets the total delay time and mockable clock.
+     * Should be called each time a new delay duration needs to be measured.
      */
     public void reset() {
-      sleepTime.set(0);
+      delayTime.set(0);
       ScalyrUtil.setCustomTimeNs(0);
     }
   }

--- a/src/test/java/com/scalyr/integrations/kafka/TestValues.java
+++ b/src/test/java/com/scalyr/integrations/kafka/TestValues.java
@@ -45,7 +45,7 @@ public abstract class TestValues {
   public static final int ADD_EVENTS_TIMEOUT_MS = 20_000;
   public static final int ADD_EVENTS_RETRY_DELAY_MS = 500;
   public static final int EXPECTED_NUM_RETRIES = 6; // Expected num of retries with ADD_EVENTS_TIMEOUT_MS and ADD_EVENTS_RETRY_DELAY_MS
-  public static final long EXPECTED_SLEEP_TIME_MS = 15_500; // Expected sleep time with ADD_EVENTS_TIMEOUT_MS and ADD_EVENTS_RETRY_DELAY_MS
+  public static final long EXPECTED_DELAY_TIME_MS = 15_500; // Expected delay time with ADD_EVENTS_TIMEOUT_MS and ADD_EVENTS_RETRY_DELAY_MS
   public static final String ENRICHMENT_VALUE = "env=test,org=Scalyr";
   public static final Map<String, String> ENRICHMENT_VALUE_MAP = TestUtils.makeMap("env", "test", "org", "Scalyr");
   public static final int MIN_BATCH_SEND_SIZE_BYTES = 500_000;


### PR DESCRIPTION
Switch for Apache HTTP client to Netty-based `AsyncHttpClient` for improved performance and throughput.
