### PR TITLE
Fix AsyncHttpClient initialization with multiple workers

### DIFF
--- a/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
+++ b/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
@@ -128,7 +128,8 @@ public class AddEventsClient implements AutoCloseable {
     this.initialBackoffDelayMs = initialBackoffDelayMs;
     this.compressor = compressor;
     this.runWithDelay = runWithDelay != null ? runWithDelay : (delayMs, task) -> retryExecutor.schedule(task, delayMs, TimeUnit.MILLISECONDS);
-    this.requestBuilder = HttpResource.acquire().preparePost(buildAddEventsUri(scalyrUrl));
+    final String addEventsUri = buildAddEventsUri(scalyrUrl);
+    this.requestBuilder = HttpResource.acquire().preparePost(addEventsUri);
     addHeaders();
   }
 
@@ -606,6 +607,8 @@ public class AddEventsClient implements AutoCloseable {
   public static class HttpResource {
     private static AsyncHttpClient asyncHttpClient;
     private static AtomicInteger count = new AtomicInteger();
+
+    private HttpResource() {}
 
     /**
      * @return Global AsyncHttpClient instance, initializing it if needed.

--- a/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
+++ b/src/main/java/com/scalyr/integrations/kafka/AddEventsClient.java
@@ -629,6 +629,7 @@ public class AddEventsClient implements AutoCloseable {
       if (count.decrementAndGet() == 0 && asyncHttpClient != null) {
         try {
           asyncHttpClient.close();
+          asyncHttpClient = null;
         } catch (IOException e) {
           throw new RuntimeException(e);
         }

--- a/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkConnector.java
+++ b/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkConnector.java
@@ -58,7 +58,6 @@ public class ScalyrSinkConnector extends SinkConnector {
     }
 
     this.configProps = Collections.unmodifiableMap(configProps);
-    AddEventsClient.HttpWrapper.start();
     log.info("Started ScalyrSinkConnector");
   }
 
@@ -81,9 +80,9 @@ public class ScalyrSinkConnector extends SinkConnector {
 
   /**
    * Stop this connector.
+   * No actions needed.
    */
   @Override public void stop() {
-    AddEventsClient.HttpWrapper.stop();
     log.info("Stopped ScalyrSinkConnector");
   }
 

--- a/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkTask.java
+++ b/src/main/java/com/scalyr/integrations/kafka/ScalyrSinkTask.java
@@ -243,6 +243,9 @@ public class ScalyrSinkTask extends SinkTask {
    */
   @Override
   public void stop() {
+    if (addEventsClient != null) {
+      addEventsClient.close();
+    }
     log.info("Stopped ScalyrSinkTask");
   }
 

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -540,7 +540,6 @@ public class AddEventsClientTest {
 
     AddEventsClient.HttpResource.release();
     AddEventsClient.HttpResource.release();
-    TestUtils.fails(() -> AddEventsClient.HttpResource.release(), IllegalStateException.class);
   }
 
   /**

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -93,6 +93,7 @@ public class AddEventsClientTest {
   private String scalyrUrl;
   private Compressor compressor;
   private Compressor deflateCompressor;
+  private AddEventsClient addEventsClient;
 
   @Before
   public void setup() {
@@ -107,6 +108,10 @@ public class AddEventsClientTest {
 
   @After
   public void tearDown() {
+    if (addEventsClient != null) {
+      addEventsClient.close();
+      addEventsClient = null;
+    }
     ScalyrUtil.removeCustomTime();
   }
 
@@ -206,7 +211,7 @@ public class AddEventsClientTest {
     server.enqueue(new MockResponse().setResponseCode(200).setBody(ADD_EVENTS_RESPONSE_SUCCESS));
 
     // Create addEvents request
-    AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor);
+    addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor);
     List<Event> events = TestUtils.createTestEvents(numEvents, numServers, numLogFiles, numParsers);
     addEventsClient.log(events);
 
@@ -231,7 +236,7 @@ public class AddEventsClientTest {
 
     // Create and verify addEvents requests
     ObjectMapper objectMapper = new ObjectMapper();
-    AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor);
+    addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor);
     for (int i = 0; i < numRequests; i++) {
       // Create addEvents request
       List<Event> events = TestUtils.createTestEvents(numEvents, numServers, numLogFiles, numParsers);
@@ -254,7 +259,7 @@ public class AddEventsClientTest {
   public void testAddEventsClientErrors() throws Exception {
     int requestCount = 0;
     MockRunWithDelay mockRunWithDelay = new MockRunWithDelay();
-    AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor, mockRunWithDelay.runWithDelay);
+    addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor, mockRunWithDelay.runWithDelay);
 
     // Server Too Busy
     TestUtils.addMockResponseWithRetries(server, new MockResponse().setResponseCode(429).setBody(ADD_EVENTS_RESPONSE_SERVER_BUSY));
@@ -303,7 +308,7 @@ public class AddEventsClientTest {
    */
   @Test
   public void testDependentRequestsSuccess() throws Exception {
-    AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor);
+    addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor);
 
     server.enqueue(new MockResponse().setResponseCode(200).setBody(ADD_EVENTS_RESPONSE_SUCCESS));
     server.enqueue(new MockResponse().setResponseCode(200).setBody(ADD_EVENTS_RESPONSE_SUCCESS));
@@ -350,7 +355,7 @@ public class AddEventsClientTest {
   @Test
   public void testDependentRequestsError() throws Exception {
     MockRunWithDelay mockRunWithDelay = new MockRunWithDelay();
-    AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor, mockRunWithDelay.runWithDelay);
+    addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor, mockRunWithDelay.runWithDelay);
 
     // MockWebServer response with server busy response for first request
     TestUtils.addMockResponseWithRetries(server, new MockResponse().setResponseCode(429).setBody(ADD_EVENTS_RESPONSE_SERVER_BUSY));
@@ -372,7 +377,7 @@ public class AddEventsClientTest {
    */
   @Test
   public void testAddEventsTimeout() throws Exception {
-    AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, 1, ADD_EVENTS_RETRY_DELAY_MS, compressor);
+    addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, 1, ADD_EVENTS_RETRY_DELAY_MS, compressor);
 
     CompletableFuture<AddEventsResponse> fakeSlowPendingRequest = new CompletableFuture<>();
     CompletableFuture<AddEventsResponse> request2 = addEventsClient.log(TestUtils.createTestEvents(1, 1, 1, 1), fakeSlowPendingRequest);
@@ -388,7 +393,7 @@ public class AddEventsClientTest {
   @Ignore("Test is slow and should not be included in automated testing")
   @Test
   public void testRetryWithoutMockRetryWithDelay() throws Exception {
-    AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor);
+    addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor);
 
     // Server Too Busy
     TestUtils.addMockResponseWithRetries(server, new MockResponse().setResponseCode(429).setBody(ADD_EVENTS_RESPONSE_SERVER_BUSY));
@@ -407,8 +412,8 @@ public class AddEventsClientTest {
     fails(() -> new AddEventsClient("http://app.scalyr.com", API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor), IllegalArgumentException.class);
 
     // Valid
-    new AddEventsClient("http://localhost:63232", API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor);
-    new AddEventsClient("https://app.scalyr.com", API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor);
+    try (AddEventsClient addEventsClient = new AddEventsClient("http://localhost:63232", API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor)) {}
+    try (AddEventsClient addEventsClient = new AddEventsClient("https://app.scalyr.com", API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor)) {};
   }
 
   /**
@@ -437,7 +442,7 @@ public class AddEventsClientTest {
     server.enqueue(new MockResponse().setResponseCode(200).setBody(ADD_EVENTS_RESPONSE_SUCCESS));
 
     // Create addEvents request
-    AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor);
+    addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor);
     List<Event> events = TestUtils.createTestEvents(numEvents, numServers, numLogFiles, numParsers);
     events.forEach(event -> event.setMessage(largeMsg));
 
@@ -485,7 +490,7 @@ public class AddEventsClientTest {
     server.enqueue(new MockResponse().setResponseCode(200).setBody(ADD_EVENTS_RESPONSE_SUCCESS));
 
     // Create addEvents request
-    AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, deflateCompressor);
+    addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, deflateCompressor);
     List<Event> events = TestUtils.createTestEvents(numEvents, numServers, numLogFiles, numParsers);
     events.forEach(event -> event.setMessage(largeMsg));
 
@@ -522,7 +527,7 @@ public class AddEventsClientTest {
 
   @Test
   public void testGetDecompressedPayloadFailedToDecompress() {
-    AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, deflateCompressor);
+    addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, deflateCompressor);
     byte[] decompressedPayload = addEventsClient.getDecompressedPayload("invalid".getBytes());
     assertEquals("unable to decompress the payload", new String(decompressedPayload));
   }
@@ -535,20 +540,20 @@ public class AddEventsClientTest {
 
     AddEventsClient.HttpResource.release();
     AddEventsClient.HttpResource.release();
+    TestUtils.fails(() -> AddEventsClient.HttpResource.release(), IllegalStateException.class);
   }
 
   /**
    * Create a single addEvents Request and verify the request body and header
    */
   private void testSingleRequestWithCompression() {
-    try {
+    try (AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor)) {
       final int numEvents = 10;
 
       // Setup Mock Server
       server.enqueue(new MockResponse().setResponseCode(200).setBody(ADD_EVENTS_RESPONSE_SUCCESS));
 
       // Create addEvents request
-      AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, compressor);
       List<Event> events = TestUtils.createTestEvents(numEvents, numServers, numLogFiles, numParsers);
       addEventsClient.log(events);
 

--- a/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/AddEventsClientTest.java
@@ -28,9 +28,9 @@ import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
+import org.asynchttpclient.AsyncHttpClient;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -93,11 +93,6 @@ public class AddEventsClientTest {
   private String scalyrUrl;
   private Compressor compressor;
   private Compressor deflateCompressor;
-
-  @BeforeClass
-  public static void setupResources() {
-    AddEventsClient.HttpWrapper.start();
-  }
 
   @Before
   public void setup() {
@@ -530,6 +525,16 @@ public class AddEventsClientTest {
     AddEventsClient addEventsClient = new AddEventsClient(scalyrUrl, API_KEY_VALUE, ADD_EVENTS_TIMEOUT_MS, ADD_EVENTS_RETRY_DELAY_MS, deflateCompressor);
     byte[] decompressedPayload = addEventsClient.getDecompressedPayload("invalid".getBytes());
     assertEquals("unable to decompress the payload", new String(decompressedPayload));
+  }
+
+  @Test
+  public void testHttpResource() {
+    final AsyncHttpClient client1 = AddEventsClient.HttpResource.acquire();
+    final AsyncHttpClient client2 = AddEventsClient.HttpResource.acquire();
+    assertEquals(client1, client2);
+
+    AddEventsClient.HttpResource.release();
+    AddEventsClient.HttpResource.release();
   }
 
   /**

--- a/src/test/java/com/scalyr/integrations/kafka/ScalyrSinkTaskTest.java
+++ b/src/test/java/com/scalyr/integrations/kafka/ScalyrSinkTaskTest.java
@@ -30,7 +30,6 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -88,11 +87,6 @@ public class ScalyrSinkTaskTest {
     Object data = recordValue.apply(1, 1, 1);
     System.out.println("Executing test with " + (data instanceof Struct ? "schema" : "schemaless") + " recordValue: " + data);
 
-  }
-
-  @BeforeClass
-  public static void setupResources() {
-    AddEventsClient.HttpWrapper.start();
   }
 
   @Before


### PR DESCRIPTION
# Issue
There was a bug in the AsyncHttpClient initialization code.  I had incorrectly thought that the `ScalyrSinkConnector` runs on all worker instances.  The `ScalyrSinkConnector` only runs on a single worker.  That single `ScalyrSinkConnector` coordinates tasks across all workers.

See diagram here: https://docs.confluent.io/platform/current/connect/concepts.html#task-rebalancing

We had tied the `AsyncHttpClient` initialization to the `ScalyrSinkConnector` life cycle, initialization the `AsyncHttpClient` on connector `start` and closing it on connector `stop`.  The issue with this, is that the `AsyncHttpClient` only gets initialized on the worker node where the connector is running and not on other worker nodes, where only the tasks are run.

`AsyncHttpClient` should last the life time of all tasks running on a worker.  There may be multiple connector tasks (i.e. tasks from connectors other than the ScalyrSinkConenctor) running on a worker node so we need to make sure we shutdown the `AsyncHttpClient` resources when all the `ScalyrSinkConnector` tasks stop.

We don't want call `AsyncHttpClient.close` until all the tasks stop on a worker node.

# Solution
The approach taken is to treat the `AsyncHttpClient` as a shared resource.  When an `AsyncHttpClient` is needed, we `acquire` it.  When it is no longer needed, we `release` it.  `acquire` will initialize `AsyncHttpClient` if needed - if not, it returns the shared instance.  It keeps track of how many times the `AsyncHttpClient` has been acquired.  `release` decrements how many `AsyncHttpClients` are in use and will `close` it if nothing is using it.

When `ScalyrSinkTask.start` is called, it creates a new `AddEventsClient`, which will `acquire` an `AsyncHttpClient`.  When `ScalyrSinkTask.stop` is called, it will `release` an `AsyncHttpClient`.